### PR TITLE
Tidy up hs source dirs calculations

### DIFF
--- a/ghc-lib-gen/src/Ghclibgen.hs
+++ b/ghc-lib-gen/src/Ghclibgen.hs
@@ -73,7 +73,7 @@ ghcLibParserIncludeDirs ghcFlavor =
 -- not the case).
 sortDiffListByLength :: Set.Set FilePath -> Set.Set FilePath -> [FilePath]
 sortDiffListByLength all excludes =
-  sortOn (Down . length) $ Set.toList (Set.difference all excludes)
+  nubOrd . sortOn (Down . length) $ Set.toList (Set.difference all excludes)
 
 -- | The "hs-source-dirs" for 'ghc-lib-parser' (actually used in two
 -- contexts, 'ghc-lib-parser.cabal' generation and when calculating
@@ -100,7 +100,7 @@ ghcLibParserHsSrcDirs forParserDepends ghcFlavor lib =
         -- 'GhcVersion.hs' IIRC).
         [ stage0GhcBoot | ghcFlavor `elem` [ GhcMaster, Ghc8101, Ghc8102, Ghc901 ] ] ++
         map takeDirectory cabalFileLibraries ++
-        askFiles lib "hs-source-dirs:"
+        filter (not . isSuffixOf ".") (askFiles lib "hs-source-dirs:")
 
       excludes = Set.fromList $
         map ("compiler" </>) (
@@ -128,7 +128,7 @@ ghcLibHsSrcDirs ghcFlavor lib =
         [ stage0Compiler ] ++
         [ stage0GhcBoot | ghcFlavor `elem` [ GhcMaster, Ghc8101, Ghc8102, Ghc901 ] ] ++ -- 'GHC.Platform' is in 'ghc-lib-parser', 'GHC.Platform.Host' is not.
         map takeDirectory cabalFileLibraries ++
-        askFiles lib "hs-source-dirs:"
+        filter (not . isSuffixOf ".") (askFiles lib "hs-source-dirs:")
       excludes = Set.fromList $
         [ "compiler/basicTypes"
         , "compiler/parser"


### PR DESCRIPTION
Remove some legacy code in `hs-source-dir` calculations that stopped making sense a long time ago. Fixes issue https://github.com/digital-asset/ghc-lib/issues/256.