### PR TITLE
Sync head; patch GHCi Message.hs

### DIFF
--- a/CI.hs
+++ b/CI.hs
@@ -57,7 +57,7 @@ data GhcFlavor = Ghc901
 
 -- Last tested gitlab.haskell.org/ghc/ghc.git at
 current :: String
-current = "6815603f271484766425ff2e37043b78da2d073c" -- 2020-11-23
+current = "ae14f160c64d20880486ba365348ef3900c84a60" -- 2020-11-28
 
 -- Command line argument generators.
 

--- a/ghc-lib-gen/src/Main.hs
+++ b/ghc-lib-gen/src/Main.hs
@@ -42,6 +42,7 @@ ghclibgen (GhclibgenOpts root target ghcFlavor) =
         applyPatchHeapClosures ghcFlavor
         applyPatchRtsIncludePaths ghcFlavor
         applyPatchGhcPrim ghcFlavor
+        applyPatchGHCiMessage ghcFlavor
         applyPatchDisableCompileTimeOptimizations ghcFlavor
         -- This invokes 'stack' strictly configured by
         -- 'hadrian/stack.yaml'.


### PR DESCRIPTION
- Sync to git@gitlab.haskell.org:ghc/ghc.git @ `ae14f160c64d20880486ba365348ef3900c84a60`
- Synthesize definition of `MIN_VERSION_ghc_heap(8,11,0)` in `libraries/ghci/GHCi/Message.hs` when `--ghc-flavor=ghc-master` to account for [this ghc-heap  MR](https://gitlab.haskell.org/ghc/ghc/-/commit/625726f988852f5779825a954609d187d9865dc1)