### PR TITLE
integrate ghc-9.2.1 builds

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -41,81 +41,79 @@ strategy:
     # +---------+-----------------+------------+
     # | OS      | ghc-lib flavour | GHC        |
     # +=========+=================+============+
+    # | linux   | ghc-master      | ghc-9.2.1  |
+    # | macOS   | ghc-master      | ghc-9.2.1  |
+    # +---------+-----------------+------------+
+    linux-ghc-master-9.2.1:
+      image: "ubuntu-latest"
+      mode: "--ghc-flavor ghc-master"
+      resolver: "ghc-9.2.1"
+      stack-yaml: "stack-exact.yaml"
+    mac-ghc-master-9.2.1:
+      image: "macOS-latest"
+      mode: "--ghc-flavor ghc-master"
+      resolver: "ghc-9.2.1"
+      stack-yaml: "stack-exact.yaml"
+
+    # just can't get a build-plan at this time. issues with extra,
+    # directory, process & time
+
+    # windows-ghc-master-9.2.1:
+    #   image: "windows-latest"
+    #   mode: "--ghc-flavor ghc-master"
+    #   resolver: "ghc-9.2.1"
+    #   stack-yaml: "stack-exact.yaml"
+
+    # +---------+-----------------+------------+
+    # | OS      | ghc-lib flavour | GHC        |
+    # +=========+=================+============+
     # | linux   | ghc-master      | ghc-9.0.1  |
     # | macOS   | ghc-master      | ghc-9.0.1  |
-    # | linux   | ghc-master      | ghc-8.10.4 |
-    # | macOS   | ghc-master      | ghc-8.10.4 |
-    # | windows | ghc-master      | ghc-8.10.4 |
+    # | linux   | ghc-master      | ghc-8.10.7 |
+    # | macOS   | ghc-master      | ghc-8.10.7 |
+    # | windows | ghc-master      | ghc-8.10.7 |
     # +---------+-----------------+------------+
     linux-ghc-master-9.0.1:
       image: "ubuntu-latest"
       mode: "--ghc-flavor ghc-master"
-      resolver: "ghc-9.0.1"
-      stack-yaml: "stack-exact.yaml"
-    linux-ghc-master-8.10.4:
+      resolver: "nightly-2021-11-14"
+      stack-yaml: "stack-901.yaml"
+    linux-ghc-master-8.10.7:
       image: "ubuntu-latest"
       mode: "--ghc-flavor ghc-master"
+      resolver: "lts-18.16"
       stack-yaml: "stack.yaml"
-      resolver: "nightly-2021-03-07"
     mac-ghc-master-9.0.1:
       image: "macOS-latest"
       mode: "--ghc-flavor ghc-master"
-      resolver: "ghc-9.0.1"
-      stack-yaml: "stack-exact.yaml"
-    mac-ghc-master-8.10.4:
+      resolver: "nightly-2021-11-14"
+      stack-yaml: "stack-901.yaml"
+    mac-ghc-master-8.10.7:
       image: "macOS-latest"
       mode: "--ghc-flavor ghc-master"
-      resolver: "nightly-2021-03-07"
+      resolver: "lts-18.16"
       stack-yaml: "stack.yaml"
-    windows-ghc-master-8.10.4:
+    windows-ghc-master-8.10.7:
       image: "windows-latest"
       mode: "--ghc-flavor ghc-master"
-      resolver: "nightly-2021-03-07"
+      resolver: "lts-18.16"
       stack-yaml: "stack.yaml"
 
     # +---------+-----------------+------------+
     # | OS      | ghc-lib flavour | GHC        |
     # +=========+=================+============+
     # | linux   | ghc-9.2.1       | ghc-9.0.1  |
-    # | macOS   | ghc-9.2.1       | ghc-8.10.6 |
+    # | macOS   | ghc-9.2.1       | ghc-8.10.7 |
     # +---------+-----------------+------------+
     linux-ghc-9.2.1-9.0.1:
       image: "ubuntu-latest"
       mode: "--ghc-flavor ghc-9.2.1"
-      resolver: "ghc-9.0.1"
-      stack-yaml: "stack-exact.yaml"
-    mac-ghc-9.2.1-8.10.6:
+      resolver: "nightly-2021-11-14"
+      stack-yaml: "stack-901.yaml"
+    mac-ghc-9.2.1-8.10.7:
       image: "macOS-latest"
       mode: "--ghc-flavor ghc-9.2.1"
-      resolver: "ghc-8.10.6"
-      stack-yaml: "stack-exact.yaml"
-
-    # +---------+-----------------+------------+
-    # | OS      | ghc-lib flavour | GHC        |
-    # +=========+=================+============+
-    # | linux   | ghc-9.0.1       | ghc-8.10.6 |
-    # | macOS   | ghc-9.0.1       | ghc-8.10.6 |
-    # +---------+-----------------+------------+
-    linux-ghc-9.0.1-8.10.6:
-      image: "ubuntu-latest"
-      mode: "--ghc-flavor ghc-9.0.1"
-      resolver: "ghc-8.10.6"
-      stack-yaml: "stack-exact.yaml"
-    mac-ghc-9.0.1-8.10.6:
-      image: "macOS-latest"
-      mode: "--ghc-flavor ghc-9.0.1"
-      resolver: "ghc-8.10.6"
-      stack-yaml: "stack-exact.yaml"
-
-    # +---------+-----------------+------------+
-    # | OS      | ghc-lib flavour | GHC        |
-    # +=========+=================+============+
-    # | linux   | ghc-8.10.6      | ghc-8.8.4  |
-    # +---------+-----------------+------------+
-    linux-ghc-8.10.6-8.8.4:
-      image: "ubuntu-latest"
-      mode: "--ghc-flavor ghc-8.10.6"
-      resolver: "nightly-2020-03-14"
+      resolver: "lts-18.16"
       stack-yaml: "stack.yaml"
 
     # +---------+-----------------+------------+
@@ -160,5 +158,6 @@ steps:
       curl -sSL https://raw.github.com/ndmitchell/hlint/master/misc/travis.sh | sh -s examples/mini-hlint/test/Main.hs
       curl -sSL https://raw.github.com/ndmitchell/hlint/master/misc/travis.sh | sh -s examples/mini-compile/src
       stack setup --stack-yaml $(stack-yaml) --resolver $(resolver) > /dev/null
+      stack install --stack-yaml $(stack-yaml) --resolver $(resolver) alex happy > /dev/null
       stack exec --stack-yaml $(stack-yaml) --resolver $(resolver) --package extra --package optparse-applicative ghc -- -package extra -package optparse-applicative -Wall -Wno-name-shadowing -Werror -c CI.hs
       stack runhaskell --stack-yaml $(stack-yaml) --resolver $(resolver) --package extra --package optparse-applicative -- CI.hs $(mode)  --stack-yaml $(stack-yaml) --resolver $(resolver)

--- a/stack-901.yaml
+++ b/stack-901.yaml
@@ -1,0 +1,18 @@
+# This is 'stack.yaml' but with an explicit version for happy
+
+# happy-1.21.0 has crept into the ghc-9.0.1 resolvers but ghc-9.2.1
+# (at least and master for now), do not admit building with this
+# version (probibted by .configure).
+
+resolver: nightly-2021-11-14 # ghc-9.0.1
+
+ghc-options:
+  # try and speed up recompilation on the CI server
+  "$everything": -O0 -j
+
+extra-deps:
+  - happy-1.20.0 # override happy-1.21.0 (can't build ghc-9.2 or head)
+
+# Packages MUST go at the end, since we append to it during the CI.hs script
+packages:
+- .

--- a/stack-exact.yaml
+++ b/stack-exact.yaml
@@ -23,65 +23,78 @@ ghc-options:
 extra-deps:
 # Dependencies of ghc-lib-parser & ghc-lib:
 - alex-3.2.6
+# Most recent happy is 1.21.0 but we can't change yet. See:
+# - the `extra-deps` section of `stack-901.yaml`
+# - 'ghc/m4/fptools_happy.m4' which is what bounds ghc above to 1.20.0
 - happy-1.20.0
 # Dependencies for ghc-lib examples:
-- hashable-1.3.1.0
+- hashable-1.4.0.0
 - syb-0.7.2.1
 - uniplate-1.6.13
-- unordered-containers-0.2.13.0
+- unordered-containers-0.2.15.0
 # Additional dependencies for CI.hs & ghc-lib-gen:
 - ansi-terminal-0.11
 - ansi-wl-pprint-0.6.9
 - clock-0.8.2
-- colour-2.3.5
-- extra-1.7.9
-- mintty-0.1.2 # Windows specific (but it does no harm).
+- colour-2.3.6
+- extra-1.7.10
+- mintty-0.1.3 # windows specific (but it does no harm).
+- Win32-2.13.1.0 # new mintty dependency
 - optparse-applicative-0.16.1.0
-- semigroups-0.19.1
-- transformers-compat-0.6.6
+- semigroups-0.19.2
+- transformers-compat-0.7.1
 # ghc-lib-gen has recently started depending on yaml
+- OneTuple-0.3.1
+- StateVar-1.2.2
 - assoc-1.0.2
-- base-compat-0.11.2
-- base-orphans-0.8.4
+- base-compat-0.12.1
+- base-compat-batteries-0.12.1
+- base-orphans-0.8.6
+- contravariant-1.5.5
 - integer-logarithms-1.0.3.1
-- random-1.2.0
+- random-1.2.1
 - split-0.2.3.4
 - vector-algorithms-0.8.0.4
 - bifunctors-5.5.11
-- splitmix-0.1.0.3
+- splitmix-0.1.0.4
 - distributive-0.6.2.1
 - comonad-5.0.8
-- aeson-1.5.6.0
-- attoparsec-0.14.1
-- base-compat-batteries-0.11.2
-- conduit-1.3.4.1
-- data-fix-0.3.1
+- aeson-2.0.2.0
+- attoparsec-0.14.2
+- conduit-1.3.4.2
+- data-fix-0.3.2
 - dlist-1.0
+- indexed-traversable-0.1.2
+- indexed-traversable-instances-0.1.1
 - libyaml-0.1.2
-- mono-traversable-1.0.15.1
-- primitive-0.7.1.0
-- resourcet-1.2.4.2
-- scientific-0.3.6.2
+- mono-traversable-1.0.15.3
+- primitive-0.7.3.0
+- resourcet-1.2.4.3
+- scientific-0.3.7.0
+- semialign-1.2.0.1
+- semigroupoids-5.3.6
 - strict-0.4.0.1
 - tagged-0.8.6.1
-- th-abstraction-0.4.2.0
+- text-short-0.1.4
+- th-abstraction-0.4.3.0
 - these-1.1.1.1
-- time-compat-1.9.5
+- time-compat-1.9.6.1
 - unliftio-core-0.2.0.1
 - uuid-types-1.0.5
-- vector-0.12.3.0
-- yaml-0.11.5.0
-- indexed-traversable-0.1.1
+- vector-0.12.3.1
+- yaml-0.11.7.0
+- witherable-0.4.2
 # Dependencies (not already covered) for golden tests
 - filepath-1.4.2.1
-- tasty-1.4.1
+- tasty-1.4.2
 - tasty-golden-2.3.4
 - utf8-string-1.0.2
-- async-2.2.3
+- async-2.2.4
 - temporary-1.3
 - unbounded-delays-0.1.1.1
 - unix-compat-0.5.3
 - wcwidth-0.0.2
+
 flags:
   transformers-compat:
     five-three: true


### PR DESCRIPTION
this PR gets ghc-9.2.1 builds in ci

- update `stack-exact.yaml` default resolver to `ghc-9.2.1` and update packages/package versions
- the 9.2.1 builds do not execute the `mini-hlint` golden tests
  - this is a stack issue; the next upgrade will unblock re-enabling them
- `ghc-lib-gen` for 9.2.1
  - `-fwarn-incomplete-uni-patterns` seems to have become the default; disable it
  - aeson got a super major version upgrade: notes on migration [here](https://github.com/haskell/aeson/issues/881)
- azure configuration updates:
  - add 9.2.1 builds and remove some older ones
  - move 9.0.1 builds off `stack-exact.yaml` and onto `stack-901.yaml` (works around a happy problem encountered when used with `stack.yaml`)
  - swap out some 8.10.4 builds for 8.10.7 ones