### PR TITLE
[ghc-api]: Ghc.Parser.Header.getOptions sig changed

### DIFF
--- a/CI.hs
+++ b/CI.hs
@@ -68,7 +68,7 @@ data GhcFlavor = Ghc922
 
 -- Last tested gitlab.haskell.org/ghc/ghc.git at
 current :: String
-current = "940feaf3c2334d6eb8b66bd9d3edd560f789c94f" -- 2022-03-25
+current = "e58d5eeb90fb0c35ff08d8d9f752eab74fc9889e" -- 2022-04-08
 
 -- Command line argument generators.
 

--- a/examples/mini-compile/src/Main.hs
+++ b/examples/mini-compile/src/Main.hs
@@ -141,14 +141,13 @@ mkDynFlags filename s = do
   parsePragmasIntoDynFlags filename s baseFlags
   where
     parsePragmasIntoDynFlags :: String -> String -> DynFlags -> IO DynFlags
-    parsePragmasIntoDynFlags fp contents dflags0 = do
-      let opts = getOptions
+    parsePragmasIntoDynFlags filepath contents dflags0 = do
 #if defined (GHC_MASTER)
-                 (initParserOpts dflags0)
+      let (_, opts) = getOptions (initParserOpts dflags0)
+                        (stringToStringBuffer contents) filepath
 #else
-                 dflags0
+      let opts = getOptions dflags0 (stringToStringBuffer contents) filepath
 #endif
-                 (stringToStringBuffer contents) fp
       (dflags, _, _) <- parseDynamicFilePragma dflags0 opts
       return dflags
 

--- a/examples/mini-hlint/src/Main.hs
+++ b/examples/mini-hlint/src/Main.hs
@@ -208,13 +208,13 @@ parse filename flags str =
 parsePragmasIntoDynFlags :: DynFlags -> FilePath -> String -> IO (Maybe DynFlags)
 parsePragmasIntoDynFlags flags filepath str =
   catchErrors $ do
-    let opts = getOptions
 #if defined (GHC_MASTER)
-                 (initParserOpts flags)
+    let (_, opts) = getOptions (initParserOpts flags)
+                      (stringToStringBuffer str) filepath
 #else
-                 flags
+    let opts = getOptions flags
+                      (stringToStringBuffer str) filepath
 #endif
-                 (stringToStringBuffer str) filepath
     (flags, _, _) <- parseDynamicFilePragma flags opts
     return $ Just flags
   where


### PR DESCRIPTION
- affects `examples/mini-hlint` & `examples/mini-compile`
- the type of `GHC.Parser.Header.getOptions` changed [in this commit](https://gitlab.haskell.org/ghc/ghc/-/commit/babb47d263e0df0fa4e16da6bf86164a2a3e07ea)
