### PR TITLE
upgrade cabal specification: 2.0

### DIFF
--- a/CI.hs
+++ b/CI.hs
@@ -68,7 +68,7 @@ data GhcFlavor = Ghc922
 
 -- Last tested gitlab.haskell.org/ghc/ghc.git at
 current :: String
-current = "e58d5eeb90fb0c35ff08d8d9f752eab74fc9889e" -- 2022-04-08
+current = "a7053a6c04496fa26a62bb3824ccc9664909a6ec" -- 2022-05-01
 
 -- Command line argument generators.
 

--- a/ghc-lib-gen/src/Ghclibgen.hs
+++ b/ghc-lib-gen/src/Ghclibgen.hs
@@ -1085,7 +1085,7 @@ generateGhcLibCabal ghcFlavor = do
           (Set.fromList parserModules))
 
     writeFile "ghc-lib.cabal" $ unlines $ map trimEnd $
-        [ "cabal-version: >=1.22"
+        [ "cabal-version: 2.0"
         , "build-type: Simple"
         , "name: ghc-lib"
         , "version: 0.1.0"
@@ -1120,7 +1120,7 @@ generateGhcLibCabal ghcFlavor = do
         , "        build-depends: Win32"
         , "    build-depends:" ] ++
         indent2 (withCommas (ghcLibBuildDepends ghcFlavor))++
-        [ "    build-tools: alex >= 3.1, happy >= 1.19.4"
+        [ "    build-tool-depends: alex:alex >= 3.1, happy:happy >= 1.19.4"
         , "    other-extensions:" ] ++ indent2 (askField lib "other-extensions:") ++
         [ "    default-extensions:" ] ++ indent2 (askField lib "default-extensions:") ++
         [ "    hs-source-dirs:" ] ++
@@ -1174,7 +1174,7 @@ generateGhcLibParserCabal :: GhcFlavor -> IO ()
 generateGhcLibParserCabal ghcFlavor = do
     (lib, _bin, parserModules) <- libBinParserModules ghcFlavor
     writeFile "ghc-lib-parser.cabal" $ unlines $ map trimEnd $
-        [ "cabal-version: >=1.22"
+        [ "cabal-version: 2.0"
         , "build-type: Simple"
         , "name: ghc-lib-parser"
         , "version: 0.1.0"
@@ -1214,7 +1214,7 @@ generateGhcLibParserCabal ghcFlavor = do
         , "        build-depends: Win32"
         , "    build-depends:" ] ++
         indent2 (withCommas (ghcLibParserBuildDepends ghcFlavor)) ++
-        [ "    build-tools: alex >= 3.1, happy >= 1.19.4"
+        [ "    build-tool-depends: alex:alex >= 3.1, happy:happy >= 1.19.4"
         , "    other-extensions:" ] ++ indent2 (askField lib "other-extensions:") ++
         [ "    default-extensions:" ] ++ indent2 (askField lib "default-extensions:") ++
         [ "    c-sources:" ] ++


### PR DESCRIPTION
hackage package uploads seem to have been made stricter in enforcing `cabal check` pass. so, this PR makes `ghc-lib-parser` and `ghc-lib` cabal 2.0 specification conformant.