### PR TITLE
adapt to change to always vendor filepath

### DIFF
--- a/CI.hs
+++ b/CI.hs
@@ -69,7 +69,7 @@ data DaFlavor = DaFlavor
 
 -- Last tested gitlab.haskell.org/ghc/ghc.git at
 current :: String
-current = "161a6f1fd62e797e978e7808a5f567fefa123f16" -- 2022-08-28
+current = "615e22789a04e74d7e02239b4580b95b077c3ae0" -- 2022-09-22
 
 -- Command line argument generators.
 

--- a/examples/ghc-lib-test-mini-hlint/test/MiniHlintTest_fail_unknown_pragma.expect
+++ b/examples/ghc-lib-test-mini-hlint/test/MiniHlintTest_fail_unknown_pragma.expect
@@ -1,2 +1,2 @@
-test/MiniHlintTest_fail_unknown_pragma.hs:5:14: error:
+test/MiniHlintTest_fail_unknown_pragma.hs:5:14: error: [GHC-46537]
     Unsupported extension: Foo

--- a/examples/ghc-lib-test-mini-hlint/test/MiniHlintTest_fatal_error-ghc-master.expect
+++ b/examples/ghc-lib-test-mini-hlint/test/MiniHlintTest_fatal_error-ghc-master.expect
@@ -1,5 +1,5 @@
 
-test/MiniHlintTest_fatal_error.hs:11:1: error:
+test/MiniHlintTest_fatal_error.hs:11:1: error: [GHC-58481]
     parse error on input `{'
    |
 11 | {

--- a/examples/ghc-lib-test-mini-hlint/test/MiniHlintTest_non_fatal_error-ghc-master.expect
+++ b/examples/ghc-lib-test-mini-hlint/test/MiniHlintTest_non_fatal_error-ghc-master.expect
@@ -1,5 +1,5 @@
 
-test/MiniHlintTest_non_fatal_error.hs:8:18: error:
+test/MiniHlintTest_non_fatal_error.hs:8:18: error: [GHC-87491]
     Found `qualified' in postpositive position. 
     Suggested fix: Perhaps you intended to use ImportQualifiedPost
   |

--- a/ghc-lib-gen/src/Main.hs
+++ b/ghc-lib-gen/src/Main.hs
@@ -45,7 +45,7 @@ ghclibgen (GhclibgenOpts root target ghcFlavor skipInit cppOpts) =
 
     init :: GhcFlavor -> IO ()
     init ghcFlavor = do
-        applyPatchTemplateHaskellCabal ghcFlavor
+        applyPatchVendorFilePath ghcFlavor
         applyPatchHadrianStackYaml ghcFlavor
         applyPatchHeapClosures ghcFlavor
         applyPatchRtsIncludePaths ghcFlavor


### PR DESCRIPTION
- [this MR](https://gitlab.haskell.org/ghc/ghc/-/merge_requests/9050) means that we always vendor filepath modules now
- there's a program (of work) to add error codes to error messages, `ghc-lib-test-mini-hlint` expect files updated for that