### PR TITLE
update azure-pipelines.yml; remove old builds

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -141,40 +141,6 @@ strategy:
     # +---------+-----------------+------------+
     # | OS      | ghc-lib flavor  | GHC        |
     # +=========+=================+============+
-    # | linux   | ghc-9.0.2       | ghc-8.10.7 |
-    # | macOS   | ghc-9.0.2       | ghc-8.8.1  |
-    # +---------+-----------------+------------+
-    linux-ghc-9.0.2-8.10.7:
-      image: "ubuntu-latest"
-      mode: "--ghc-flavor ghc-9.0.2"
-      resolver: "lts-18.16"
-      stack-yaml: "stack.yaml"
-    mac-ghc-9.0.2-8.8.1:
-      image: "macOS-latest"
-      mode: "--ghc-flavor ghc-9.0.2"
-      resolver: "nightly-2020-01-08"
-      stack-yaml: "stack.yaml"
-
-    # +---------+-----------------+------------+
-    # | OS      | ghc-lib flavor  | GHC        |
-    # +=========+=================+============+
-    # | linux   | ghc-8.10.7      | ghc-8.8.1  |
-    # | macOS   | ghc-8.10.7      | ghc-8.8.1  |
-    # +---------+-----------------+------------+
-    linux-ghc-8.10.7-8.8.1:
-      image: "ubuntu-latest"
-      mode: "--ghc-flavor ghc-8.10.7"
-      resolver: "nightly-2020-01-08"
-      stack-yaml: "stack.yaml"
-    mac-ghc-8.10.7-8.8.1:
-      image: "macOS-latest"
-      mode: "--ghc-flavor ghc-8.10.7"
-      resolver: "nightly-2020-01-08"
-      stack-yaml: "stack.yaml"
-
-    # +---------+-----------------+------------+
-    # | OS      | ghc-lib flavor  | GHC        |
-    # +=========+=================+============+
     # | linux   | da-ghc-8.8.1    | ghc-8.8.1  |
     # | windows | da-ghc-8.8.1    | ghc-8.8.1  |
     # | macOS   | da-ghc-8.8.1    | ghc-8.8.1  |


### PR DESCRIPTION
1/3
it seems reasonable to stop testing builds GHC < 9.0.1 builds now. this pr removes those pipelines.