### PR TITLE
Error message printing

### DIFF
--- a/CI.hs
+++ b/CI.hs
@@ -69,7 +69,7 @@ data DaFlavor = DaFlavor
 
 -- Last tested gitlab.haskell.org/ghc/ghc.git at
 current :: String
-current = "615e22789a04e74d7e02239b4580b95b077c3ae0" -- 2022-09-29
+current = "2209665273135644f1b52470ea2cb53169f2ef91" -- 2022-10-02
 
 -- Command line argument generators.
 
@@ -284,7 +284,7 @@ buildDists
         toDelete  = ghcDirs ++ tarBalls ++ lockFiles
     forM_ toDelete removePath
     cmd $ "git checkout " ++ stackConfig
-    cmd "git checkout examples"
+    cmd "git checkout ghc-lib-gen.cabal examples"
 
     -- Get packages missing on Windows needed by hadrian.
     when isWindows $

--- a/CI.hs
+++ b/CI.hs
@@ -69,7 +69,7 @@ data DaFlavor = DaFlavor
 
 -- Last tested gitlab.haskell.org/ghc/ghc.git at
 current :: String
-current = "2209665273135644f1b52470ea2cb53169f2ef91" -- 2022-10-02
+current = "b17cfc9c4b341e122294c0701803fc8f521fa210" -- 2022-10-20
 
 -- Command line argument generators.
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -170,18 +170,39 @@ steps:
       brew install automake
     condition: eq( variables['Agent.OS'], 'Darwin' )
     displayName: Install brew
-  - script: |
-      set -e
+  - bash: |
       curl -sSL https://get.haskellstack.org/ | sh -s - -f
-      curl -sSL https://raw.github.com/ndmitchell/hlint/master/misc/travis.sh | sh -s CI.hs
-      curl -sSL https://raw.github.com/ndmitchell/hlint/master/misc/travis.sh | sh -s ghc-lib-gen
-      curl -sSL https://raw.github.com/ndmitchell/hlint/master/misc/travis.sh | sh -s examples/ghc-lib-test-utils/src
-      curl -sSL https://raw.github.com/ndmitchell/hlint/master/misc/travis.sh | sh -s examples/ghc-lib-test-mini-hlint/src
-      curl -sSL https://raw.github.com/ndmitchell/hlint/master/misc/travis.sh | sh -s examples/ghc-lib-test-mini-hlint/test/Main.hs
-      curl -sSL https://raw.github.com/ndmitchell/hlint/master/misc/travis.sh | sh -s examples/ghc-lib-test-mini-compile/src
+    displayName: install Stack
+  - bash: |
+      set -euo pipefail
+
+      version=$(curl -Is https://github.com/ndmitchell/hlint/releases/latest | grep location: | sed 's|.*/||' | tr -d '\n\r')
+      echo "VERSION: $version"
+
+      temp=$(mktemp -d)
+      curl -sSL https://github.com/ndmitchell/hlint/releases/download/$version/hlint-${version#v}-x86_64-linux.tar.gz > $temp/tarball
+
+      tar -xzf $temp/tarball -C$temp
+
+      hlint() (
+        echo
+        echo DEBUG: hlint "$@"
+        $temp/hlint-${version#v}/hlint "$@"
+      )
+
+      hlint CI.hs
+      hlint ghc-lib-gen
+      hlint examples/ghc-lib-test-utils/src
+      hlint examples/ghc-lib-test-mini-hlint/src
+      hlint examples/ghc-lib-test-mini-hlint/test/Main.hs
+      hlint examples/ghc-lib-test-mini-compile/src
+    displayName: run hlint
+    condition: eq( variables['Agent.OS'], 'Linux' )
   - bash: |
       stack exec --stack-yaml $(stack-yaml) --resolver $(resolver) --package extra --package optparse-applicative ghc -- -package extra -package optparse-applicative -Wall -Wno-name-shadowing -Werror -c CI.hs
       stack exec --stack-yaml $(stack-yaml) --resolver $(resolver) -- pacman -Syu --noconfirm
     condition: eq(variables['Agent.OS'], 'Windows_NT')
+    displayName: Windows pre-build
   - bash: |
       stack runhaskell --stack-yaml $(stack-yaml) --resolver $(resolver) --package extra --package optparse-applicative -- CI.hs $(mode)  --stack-yaml $(stack-yaml) --resolver $(resolver)
+    displayName: build

--- a/examples/ghc-lib-test-mini-hlint/src/Main.hs
+++ b/examples/ghc-lib-test-mini-hlint/src/Main.hs
@@ -2,6 +2,7 @@
 -- its affiliates. All rights reserved. SPDX-License-Identifier:
 -- (Apache-2.0 OR BSD-3-Clause)
 
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE PackageImports #-}
 {-# OPTIONS_GHC -Wno-missing-fields #-}
@@ -219,7 +220,9 @@ parsePragmasIntoDynFlags flags filepath str =
       putStrLn $ head
              [ showSDoc flags msg
              | msg <-
-#if defined (GHC_MASTER) || defined (GHC_941)
+#if defined (GHC_MASTER)
+                      pprMsgEnvelopeBagWithLocDefault . getMessages
+#elif defined (GHC_941)
                       pprMsgEnvelopeBagWithLoc . getMessages
 #elif defined (GHC_921)
                       pprMsgEnvelopeBagWithLoc
@@ -321,11 +324,13 @@ main = do
     _ -> fail "Exactly one file argument required"
   where
 
-#if defined (GHC_MASTER) || defined (GHC_941)
-    -- Nowdays, to print hints along with errors you need 'printMessages'.
-    -- See
-    -- https://gitlab.haskell.org/ghc/ghc/-/merge_requests/6087#note_365215
-    -- for details.
+#if defined (GHC_MASTER)
+    report flags msgs = do
+      logger <- initLogger
+      let opts = initDiagOpts flags
+      let print_config = initPrintConfig flags
+      printMessages logger print_config opts msgs
+#elif defined (GHC_941)
     report flags msgs = do
       logger <- initLogger
       let opts = initDiagOpts flags


### PR DESCRIPTION
- MR [Allow configuration of error message printing](https://gitlab.haskell.org/ghc/ghc/-/merge_requests/8563)
- generalizes `pprLocMsgEnvelope`
- update call-sites to call the newly added `pprLocMsgEnvelopeDefault`
- `printMessages` requires a new argument and enabling `GADTs`