### PR TITLE
hadrian now generates cabal files

### DIFF
--- a/ghc-lib-gen/src/Ghclibgen.hs
+++ b/ghc-lib-gen/src/Ghclibgen.hs
@@ -298,6 +298,10 @@ parsersAndLexers ghcFlavor =
 -- | Cabal "extra-source-files" files for ghc-lib-parser.
 ghcLibParserExtraFiles :: GhcFlavor -> [FilePath]
 ghcLibParserExtraFiles ghcFlavor =
+      -- It's no longer `configure` that does the substitutions on the
+      -- '.cabal.in' files to produce the '.cabal' files, rather,
+      -- hadrian.
+      [ f | ghcFlavor > Ghc943, f <- cabalFileBinary : cabalFileLibraries ] ++
       rtsDependencies ghcFlavor ++
       compilerDependencies ghcFlavor ++
       platformH ghcFlavor ++


### PR DESCRIPTION
"Don't let configure perform trivial substitutions ([#21846](https://gitlab.haskell.org/ghc/ghc/-/issues/21846))" requires we we add the cabal files to the list of things we request hadrian generate (cc @hysl20).  