### PR TITLE
fix stack yaml

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-20.6 # ghc-9.2.5
+resolver: nightly-2023-02-04 # ghc-9.4.4
 
 ghc-options:
   # try and speed up recompilation on the CI server


### PR DESCRIPTION
stack-yaml should specify a ghc sufficiently recent as to build ghc-master so in this case needs bumping to a ghc-9.4 resolver.

this branch is stacked on https://github.com/shayne-fletcher/ghc-lib/pull/155