### PR TITLE
forward compatibility fixes for ghc-9.6.1 as a build compiler

### DIFF
--- a/CI.hs
+++ b/CI.hs
@@ -71,7 +71,7 @@ data DaFlavor = DaFlavor
 
 -- Last tested gitlab.haskell.org/ghc/ghc.git at
 current :: String
-current = "7825fef9f2096d7769baf433c6858d132af60a3a" -- 2023-02-25
+current = "bf43ba9215a726039ace7bac37c0a223a912d998" -- 2023-03-04
 
 -- Command line argument generators.
 
@@ -460,7 +460,7 @@ buildDists
       writeCmdFile :: String -> FilePath -> Maybe String -> IO FilePath
       writeCmdFile exe stackConfig resolver = do
         let filename = exe
-        let cmd = "stack " ++ stackYamlOpt (Just $ "../.." </> stackConfig) ++ " " ++ stackResolverOpt resolver ++ " " ++ "exec -- " ++ exe ++ " "
+        let cmd = "stack --silent " ++ stackYamlOpt (Just $ "../.." </> stackConfig) ++ " " ++ stackResolverOpt resolver ++ " " ++ "exec -- " ++ exe ++ " "
         writeFile filename cmd
         pure filename
 

--- a/examples/ghc-lib-test-mini-hlint/test/Main.hs
+++ b/examples/ghc-lib-test-mini-hlint/test/Main.hs
@@ -70,4 +70,4 @@ testMiniHlintRespectDynamicPragmaHs :: CommandFile -> IO ()
 testMiniHlintRespectDynamicPragmaHs (CommandFile miniHlint) = do
   cmd <- readFile' miniHlint
   out <- systemOutput_ $ cmd ++ "test/MiniHlintTest_respect_dynamic_pragma.hs"
-  assertEqual "MiniHlint_respect_dynamic_pragma.hs" out ""  -- True if the the test file parses
+  assertBool "MiniHlint_respect_dynamic_pragma.hs" (null out) -- True if the the test file parses

--- a/ghc-lib-gen/src/Ghclibgen.hs
+++ b/ghc-lib-gen/src/Ghclibgen.hs
@@ -1059,7 +1059,7 @@ commonBuildDepends ghcFlavor =
       , "array >= 0.1 && < 0.6"
       , "deepseq >= 1.4 && < 1.5"
       , "pretty == 1.1.*"
-      , "transformers == 0.5.*"
+      , "transformers >= 0.5 && < 0.7"
       , "process >= 1 && < 1.7"
       ]
 

--- a/stack-exact.yaml
+++ b/stack-exact.yaml
@@ -16,9 +16,7 @@ ghc-options:
 extra-deps:
 # Dependencies of ghc-lib-parser & ghc-lib:
 - alex-3.2.7.1
-# Most recent happy is 1.21.0 but we can't change yet. See:
-# 'ghc/m4/fptools_happy.m4' which is what bounds ghc above to 1.20.0
-- happy-1.20.0
+- happy-1.20.1.1
 # Dependencies for ghc-lib examples:
 - data-array-byte-0.1.0.1
 - hashable-1.4.2.0


### PR DESCRIPTION
forward compatibility fixes for ghc-9.6.1 as a build compiler:

- bump happy-1.20.1.1 in 'stack-exact.yaml'
- bump transformers: >= 0.5 && < 0.7 in 'ghc-lib-parser.cabal'/'ghc-lib.cabal'
- add `--silent` to ghc-lib-mini-hlint & ghc-lib-mini-compile commands (avoid "stack has not been tested with 9.6 warnings")

incidental refactor:
- simplify test assertion in ghc-lib-mini-hlint-test