### PR TITLE
ghc sources now depend on semaphore-compat

### DIFF
--- a/CI.hs
+++ b/CI.hs
@@ -71,7 +71,7 @@ data DaFlavor = DaFlavor
 
 -- Last tested gitlab.haskell.org/ghc/ghc.git at
 current :: String
-current = "6f885e6575eb741556d6e198d1a9dbdadf10307b" -- 2023-03-30
+current = "1db30fe1dd38dd8ffedfadf3845706fcde02933b" -- 2023-04-21
 
 -- Command line argument generators.
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -57,11 +57,14 @@ strategy:
       mode: "--ghc-flavor ghc-master"
       resolver: "ghc-9.6.1"
       stack-yaml: "stack-exact.yaml"
-    windows-ghc-master-9.6.1:
-      image: "windows-latest"
-      mode: "--ghc-flavor ghc-master"
-      resolver: "ghc-9.6.1"
-      stack-yaml: "stack-exact.yaml"
+    # 'semaphore-compat' (Apr 2023) requires Win32-2.13.4 but Win32 is
+    # a boot lib and ghc-9.6.1 ships with 2.13.3. I haven't yet found
+    # a way to get a build plan for this scenario.
+    # windows-ghc-master-9.6.1:
+    #   image: "windows-latest"
+    #   mode: "--ghc-flavor ghc-master"
+    #   resolver: "ghc-9.6.1"
+    #   stack-yaml: "stack-exact.yaml"
 
     # +---------+-----------------+------------+
     # | OS      | ghc-lib flavor  | GHC        |

--- a/ghc-lib-gen/src/Ghclibgen.hs
+++ b/ghc-lib-gen/src/Ghclibgen.hs
@@ -1024,6 +1024,11 @@ commonBuildDepends ghcFlavor =
     -- base
     base = [ baseBounds ghcFlavor ]
     specific
+       | ghcSeries ghcFlavor >= Ghc97 = [
+           "ghc-prim > 0.2 && < 0.11"
+         , "bytestring >= 0.11.3 && < 0.12"
+         , "time >= 1.4 && < 1.13"
+         ]
        | ghcSeries ghcFlavor >= Ghc96  = [
            "ghc-prim > 0.2 && < 0.11"
          , "bytestring >= 0.11.3 && < 0.12"
@@ -1045,6 +1050,13 @@ commonBuildDepends ghcFlavor =
           , "time >= 1.4 && < 1.10"
           ]
     conditional
+        | ghcSeries ghcFlavor >= Ghc97 = [
+            "exceptions == 0.10.*"
+          , "parsec"
+            -- Dependency added after ghc-9.6.1. New boot lib that
+            -- depends on the boot libs unix and win32.
+          , "semaphore-compat"
+         ]
         | ghcSeries ghcFlavor >= Ghc90 = [
             "exceptions == 0.10.*"
           , "parsec"

--- a/stack-exact.yaml
+++ b/stack-exact.yaml
@@ -90,6 +90,16 @@ extra-deps:
 - unix-compat-0.6
 - wcwidth-0.0.2
 
+# Since Apr 2023 ghc depends on semaphore-compat. It is set to be a
+# boot library but for now we can go to Hackage. It depends on unix
+# and Win32 both of which are boot libraries. ghc-9.6.1 ships with a
+# recent enough version of unix (2.8.1.0) but not Win32 where 2.13.4.0
+# is needed but ghc-9.6.1 comes with 2.13.3 so now we can't build
+# master on Windows. ghc-9.4.4 ships with unix-2.7.3 so that can't be
+# used to build on any platform.
+
+- semaphore-compat-1.0.0
+
 flags:
   # Win32 is a compiler lib, the version with ghc-9.6.1 is 2.13.3.0
   # (https://www.snoyman.com/base/)

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,5 +1,8 @@
 resolver: nightly-2023-02-04 # ghc-9.4.4
 
+extra-deps:
+- semaphore-compat-1.0.0
+
 ghc-options:
   # try and speed up recompilation on the CI server
   "$everything": -O0 -j


### PR DESCRIPTION
new boot lib dep semaphore-compat introduced by [this commit](https://gitlab.haskell.org/ghc/ghc/-/commit/5c8731244bc13a3d813d2a4d53b3188b28dc8355). 