### PR TITLE
applyPatchAclocal tiny fix

### DIFF
--- a/ghc-lib-gen/src/Ghclibgen.hs
+++ b/ghc-lib-gen/src/Ghclibgen.hs
@@ -832,7 +832,7 @@ applyPatchStage ghcFlavor =
 -- how it currently is on HEAD.
 applyPatchAclocal :: GhcFlavor -> IO ()
 applyPatchAclocal ghcFlavor =
-  when (ghcFlavor == Ghc901) $
+  when (ghcFlavor <= Ghc901) $
     writeFile aclocalm4 .
       replace "_AC_PROG_CC_C99" "AC_PROG_CC_C99"
     =<< readFile' aclocalm4


### PR DESCRIPTION
adjustment to `applyPatchAclocal` to recover ghc-flavor < ghc-9.0.1 builds