### PR TITLE
ghc 9.6.2

### DIFF
--- a/CI.hs
+++ b/CI.hs
@@ -52,7 +52,7 @@ data StackOptions = StackOptions
 
 data GhcFlavor = Da DaFlavor
                | GhcMaster String
-               | Ghc961
+               | Ghc961 | Ghc962
                | Ghc945 | Ghc944 | Ghc943 | Ghc942 | Ghc941
                | Ghc927 | Ghc926 | Ghc925 | Ghc924 | Ghc923 | Ghc922 | Ghc921
                | Ghc902 | Ghc901
@@ -71,7 +71,7 @@ data DaFlavor = DaFlavor
 
 -- Last tested gitlab.haskell.org/ghc/ghc.git at
 current :: String
-current = "735d504ee4d7a0635d9baaa76d28673cf3947dd4" -- 2023-05-22
+current = "6abf36483a41e50579afcea1497f502875693913" -- 2023-05-23
 
 -- Command line argument generators.
 
@@ -87,6 +87,7 @@ stackResolverOpt = \case
 
 ghcFlavorOpt :: GhcFlavor -> String
 ghcFlavorOpt = \case
+    Ghc962 -> "--ghc-flavor ghc-9.6.2"
     Ghc961 -> "--ghc-flavor ghc-9.6.1"
     Ghc945 -> "--ghc-flavor ghc-9.4.5"
     Ghc944 -> "--ghc-flavor ghc-9.4.4"
@@ -149,6 +150,7 @@ genVersionStr flavor suffix =
     base = case flavor of
       Da {}       -> "8.8.1"
       GhcMaster _ -> "0"
+      Ghc962      -> "9.6.2"
       Ghc961      -> "9.6.1"
       Ghc945      -> "9.4.5"
       Ghc944      -> "9.4.4"
@@ -203,6 +205,7 @@ parseOptions = Options
  where
    readFlavor :: Opts.ReadM GhcFlavor
    readFlavor = Opts.eitherReader $ \case
+       "ghc-9.6.2" -> Right Ghc962
        "ghc-9.6.1" -> Right Ghc961
        "ghc-9.4.5" -> Right Ghc945
        "ghc-9.4.4" -> Right Ghc944
@@ -587,6 +590,7 @@ buildDists
 
       branch :: GhcFlavor -> String
       branch = \case
+          Ghc962  -> "ghc-9.6.2-release"
           Ghc961  -> "ghc-9.6.1-release"
           Ghc945  -> "ghc-9.4.5-release"
           Ghc944  -> "ghc-9.4.4-release"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -66,23 +66,23 @@ strategy:
     # +---------+-----------------+------------+
     # | OS      | ghc-lib flavor  | GHC        |
     # +=========+=================+============+
-    # | linux   | ghc-9.6.1       | ghc-9.4.5  |
-    # | macOS   | ghc-9.6.1       | ghc-9.4.5  |
-    # | windows | ghc-9.6.1       | ghc-9.4.4  |
+    # | linux   | ghc-9.6.2       | ghc-9.4.5  |
+    # | macOS   | ghc-9.6.2       | ghc-9.4.5  |
+    # | windows | ghc-9.6.2       | ghc-9.4.4  |
     # +---------+-----------------+------------+
-    linux-ghc-9.6.1-9.4.5:
+    linux-ghc-9.6.2-9.4.5:
       image: "ubuntu-22.04"
-      mode: "--ghc-flavor ghc-9.6.1"
+      mode: "--ghc-flavor ghc-9.6.2"
       resolver: "ghc-9.4.5"
       stack-yaml: "stack-exact.yaml"
-    mac-ghc-9.6.1-9.4.5:
+    mac-ghc-9.6.2-9.4.5:
       image: "macOS-latest"
-      mode: "--ghc-flavor ghc-9.6.1"
+      mode: "--ghc-flavor ghc-9.6.2"
       resolver: "ghc-9.4.5"
       stack-yaml: "stack-exact.yaml"
-    windows-ghc-9.6.1-9.4.4:
+    windows-ghc-9.6.2-9.4.4:
       image: "windows-latest"
-      mode: "--ghc-flavor ghc-9.6.1"
+      mode: "--ghc-flavor ghc-9.6.2"
       resolver: "nightly-2023-03-17"
       stack-yaml: "stack.yaml"
 

--- a/examples/ghc-lib-test-utils/src/TestUtils.hs
+++ b/examples/ghc-lib-test-utils/src/TestUtils.hs
@@ -44,6 +44,7 @@ data GhcVersion = DaGhc881
                 | Ghc944
                 | Ghc945
                 | Ghc961
+                | Ghc962
                 | GhcMaster
   deriving (Eq, Ord, Typeable)
 
@@ -52,6 +53,7 @@ instance Show GhcVersion where
 
 showGhcVersion :: GhcVersion -> String
 showGhcVersion = \case
+    Ghc962 -> "ghc-9.6.2"
     Ghc961 -> "ghc-9.6.1"
     Ghc945 -> "ghc-9.4.5"
     Ghc944 -> "ghc-9.4.4"
@@ -85,6 +87,7 @@ readFlavor = (GhcFlavor <$>) . \case
     -- HEAD
     "ghc-master" -> Just GhcMaster
     -- ghc-9.6
+    "ghc-9.6.2" -> Just Ghc962
     "ghc-9.6.1" -> Just Ghc961
     -- ghc-9.4
     "ghc-9.4.5" -> Just Ghc945

--- a/ghc-lib-gen/src/Ghclibgen.hs
+++ b/ghc-lib-gen/src/Ghclibgen.hs
@@ -1053,7 +1053,9 @@ baseBounds = \case
     Ghc945   -> "base >= 4.15 && < 4.18" -- [ghc-9.0.1, ghc-9.6.1)
 
     -- require bytestring >= 0.11.3 which rules out ghc-9.2.1
-    Ghc961   -> "base >= 4.16.1 && < 4.19" -- [ghc-9.2.2, ghc-9.7.1)
+    -- base-4.18.0
+    Ghc961   -> "base >= 4.16.1 && < 4.19" -- [ghc-9.2.2, ghc-9.8.1)
+    Ghc962   -> "base >= 4.16.1 && < 4.19" -- [ghc-9.2.2, ghc-9.8.1)
 
     GhcMaster -- e.g. "9.7.20230119"
               -- (c.f. 'rts/include/ghc-version.h'')

--- a/ghc-lib-gen/src/GhclibgenFlavor.hs
+++ b/ghc-lib-gen/src/GhclibgenFlavor.hs
@@ -14,7 +14,7 @@ data GhcFlavor = DaGhc881
                | Ghc901 | Ghc902
                | Ghc921 | Ghc922 | Ghc923 | Ghc924 | Ghc925 | Ghc926 | Ghc927
                | Ghc941 | Ghc942 | Ghc943 | Ghc944 | Ghc945
-               | Ghc961
+               | Ghc961 | Ghc962
                | GhcMaster
   deriving (Show, Eq, Ord)
 

--- a/ghc-lib-gen/src/GhclibgenOpts.hs
+++ b/ghc-lib-gen/src/GhclibgenOpts.hs
@@ -86,6 +86,7 @@ readFlavor = eitherReader $ \case
     "ghc-master" -> Right GhcMaster
 
     -- ghc-9.6
+    "ghc-9.6.2" -> Right Ghc962
     "ghc-9.6.1" -> Right Ghc961
 
     -- ghc-9.4


### PR DESCRIPTION
ghc-9.6.2 released 2023-05-23, this adds support for it. note this branch is on top of https://github.com/digital-asset/ghc-lib/pull/454 and so will need rebasing on master once that's landed before we land this. 