### PR TITLE
treat 'ghc-platform' as a boot library

### DIFF
--- a/CI.hs
+++ b/CI.hs
@@ -74,7 +74,7 @@ data DaFlavor = DaFlavor
 
 -- Last tested gitlab.haskell.org/ghc/ghc.git at
 current :: String
-current = "eb1a6ab1df473c7ec0e1cbb20fc7124706326ce1" -- 2023-07-16
+current = "b55a8ea70424032c19ef85ef95c5eee8b50d55c3" -- 2023-07-17
 
 -- Command line argument generators.
 


### PR DESCRIPTION
[Split GHC.Platform.ArchOS from ghc-boot into ghc-platform](https://gitlab.haskell.org/ghc/ghc/-/merge_requests/10696) has landed. since it won't be released until 9.10 (see comments) treat it as a boot library for now.