### PR TITLE
ghc-llvm.h is removed

### DIFF
--- a/CI.hs
+++ b/CI.hs
@@ -75,7 +75,7 @@ data DaFlavor = DaFlavor
 
 -- Last tested gitlab.haskell.org/ghc/ghc.git at
 current :: String
-current = "cdddeb0f1280b40cc194028bbaef36e127175c4c" -- 2024-02-03
+current = "9f987235c8f20df55b9b16c8f9e0232288c9faeb" -- 2024-02-08
 
 -- Command line argument generators.
 

--- a/ghc-lib-gen/src/Ghclibgen.hs
+++ b/ghc-lib-gen/src/Ghclibgen.hs
@@ -245,11 +245,14 @@ fingerprint ghcFlavor =
 
 cHeaders :: GhcFlavor -> [String]
 cHeaders ghcFlavor =
-   [ f | ghcSeries ghcFlavor > GHC_9_8, f <- ("rts/include/stg/MachRegs" </>) <$> ["arm32.h", "arm64.h", "loongarch64.h", "ppc.h", "riscv64.h", "s390x.h", "wasm32.h", "x86.h"] ] ++
-   [ f | ghcSeries ghcFlavor >= GHC_9_8, f <- [ "libraries/containers/containers/include/containers.h" ] ] ++
-   [ f | ghcSeries ghcFlavor >= GHC_9_4, f <- (("rts/include" </>) <$> ["ghcconfig.h", "ghcversion.h" ]) ++ (("compiler" </>) <$>[ "MachRegs.h", "CodeGen.Platform.h", "Bytecodes.h", "ClosureTypes.h", "FunTypes.h", "Unique.h", "ghc-llvm-version.h" ]) ] ++
-   [ f | ghcSeries ghcFlavor < GHC_9_4, f <- (("includes" </>)  <$> [ "MachDeps.h", "stg/MachRegs.h", "CodeGen.Platform.hs"]) ++ (("compiler" </>) <$> [ "Unique.h", "HsVersions.h" ]) ] ++
-   [ f | ghcSeries ghcFlavor < GHC_8_10, f <- ("compiler" </>) <$> [ "nativeGen/NCG.h", "utils/md5.h"] ]
+   [ f | series > GHC_9_8, f <- ("rts/include/stg/MachRegs" </>) <$> ["arm32.h", "arm64.h", "loongarch64.h", "ppc.h", "riscv64.h", "s390x.h", "wasm32.h", "x86.h"] ] ++
+   [ "libraries/containers/containers/include/containers.h" | series >= GHC_9_8 ] ++
+   [ "compiler" </> "ghc-llvm-version.h" | series >= GHC_9_4 && series <= GHC_9_8 ] ++
+   [ f | series >= GHC_9_4, f <- (("rts/include" </>) <$> ["ghcconfig.h", "ghcversion.h" ]) ++ (("compiler" </>) <$>[ "MachRegs.h", "CodeGen.Platform.h", "Bytecodes.h", "ClosureTypes.h", "FunTypes.h", "Unique.h" ]) ] ++
+   [ f | series < GHC_9_4, f <- (("includes" </>)  <$> [ "MachDeps.h", "stg/MachRegs.h", "CodeGen.Platform.hs"]) ++ (("compiler" </>) <$> [ "Unique.h", "HsVersions.h" ]) ] ++
+   [ f | series < GHC_8_10, f <- ("compiler" </>) <$> [ "nativeGen/NCG.h", "utils/md5.h"] ]
+  where
+    series = ghcSeries ghcFlavor
 
 parsersAndLexers :: GhcFlavor -> [FilePath]
 parsersAndLexers ghcFlavor = ("compiler" </>) <$>


### PR DESCRIPTION
fixes [this failure](https://github.com/shayne-fletcher/hlint-from-scratch/actions/runs/7837771337/job/21388074711#step:8:6729)

in [this upstream commit](https://gitlab.haskell.org/ghc/ghc/-/commit/c37931b35c47dfe0ac1acea25943f3af2396e7fd) ghc-llvm.h is removed. this pr removes it from ghc-lib-gen.


