### PR TITLE
constrain alex to < 3.5.1.0

### DIFF
--- a/CI.hs
+++ b/CI.hs
@@ -76,7 +76,7 @@ data DaFlavor = DaFlavor
 
 -- Last tested gitlab.haskell.org/ghc/ghc.git at
 current :: String
-current = "e6bfb85c842edca36754bb8914e725fbaa1a83a6" -- 2024-03-13
+current = "8d67f247c3e4ca3810712654e1becbf927405f6b" -- 2024-03-24
 
 -- Command line argument generators.
 

--- a/ghc-lib-gen/src/Ghclibgen.hs
+++ b/ghc-lib-gen/src/Ghclibgen.hs
@@ -1336,7 +1336,7 @@ generateGhcLibCabal ghcFlavor customCppOpts = do
         , "        build-depends: Win32"
         , "    build-depends:" ] ++
         indent2 (Data.List.NonEmpty.toList (withCommas (ghcLibBuildDepends ghcFlavor)))++
-        [ "    build-tool-depends: alex:alex >= 3.1, happy:happy >= 1.19.4"
+        [ "    build-tool-depends: alex:alex >= 3.1 && < 3.5.1.0, happy:happy >= 1.19.4"
         , "    other-extensions:" ] ++ indent2 (askField lib "other-extensions:") ++
         [ "    default-extensions:" ] ++ indent2 (askField lib "default-extensions:") ++
         [ "        GHC2021" | ghcFlavor > Ghc982 ] ++
@@ -1429,7 +1429,7 @@ generateGhcLibParserCabal ghcFlavor customCppOpts = do
         , "        build-depends: Win32"
         , "    build-depends:" ] ++
         indent2 (Data.List.NonEmpty.toList (withCommas (ghcLibParserBuildDepends ghcFlavor))) ++
-        [ "    build-tool-depends: alex:alex >= 3.1, happy:happy >= 1.19.4"
+        [ "    build-tool-depends: alex:alex >= 3.1 && < 3.5.1.0, happy:happy >= 1.19.4"
         , "    other-extensions:" ] ++ indent2 (askField lib "other-extensions:") ++
         [ "    default-extensions:" ] ++ indent2 (askField lib "default-extensions:") ++
         [ "        GHC2021" | ghcFlavor > Ghc982 ] ++


### PR DESCRIPTION
3.5.1.0 is incompatible with GHC HEAD (see https://gitlab.haskell.org/ghc/ghc/-/issues/24583)