### PR TITLE
refactor ghc-lib-gen.cabal

### DIFF
--- a/CI.hs
+++ b/CI.hs
@@ -443,10 +443,10 @@ buildDists
     verifyConstraint "ghc-lib-parser == " version "examples/ghc-lib-test-mini-compile/ghc-lib-test-mini-compile.cabal"
     verifyConstraint "ghc-lib == " version "examples/ghc-lib-test-mini-compile/ghc-lib-test-mini-compile.cabal"
 
-    stack "sdist . --ignore-check --tar-dir=."
-    stack "sdist examples/ghc-lib-test-utils --tar-dir=."
-    stack "sdist examples/ghc-lib-test-mini-hlint --tar-dir=."
-    stack "sdist examples/ghc-lib-test-mini-compile --tar-dir=."
+    cmd "cabal sdist -o ."
+    cmd "(cd examples/ghc-lib-test-utils && cabal sdist -o ..)"
+    cmd "(cd examples/ghc-lib-test-mini-hlint && cabal sdist -o ..)"
+    cmd "(cd examples/ghc-lib-test-mini-compile && cabal sdist -o ..)"
 
     when noBuilds exitSuccess
 

--- a/Setup.hs
+++ b/Setup.hs
@@ -1,0 +1,2 @@
+import Distribution.Simple
+main = defaultMain

--- a/ghc-lib-gen.cabal
+++ b/ghc-lib-gen.cabal
@@ -1,47 +1,46 @@
-cabal-version:       2.0
-name:                ghc-lib-gen
-version:             0.1.0.0
-synopsis:            Cabal file generator for GHC as a library
-description:         Generate a cabal file for a subset of GHC for use as a library.
-homepage:            https://github.com/digital-asset/ghc-lib
-license:             BSD3
-x-license:           BSD-3-Clause OR Apache-2.0
-license-file:        LICENSE
-author:              Shayne Fletcher (shayne.fletcher@digitalasset.com)
-maintainer:          Shayne Fletcher (shayne.fletcher@digitalasset.com)
-copyright:           Digital Asset 2018-2019
-category:            Development
-build-type:          Simple
+cabal-version: 3.4
+name: ghc-lib-gen
+version: 0.1.0.0
+synopsis: Cabal file generator for GHC as a library
+description: Generate a cabal file for a subset of GHC for use as a library.
+homepage:https://github.com/digital-asset/ghc-lib
+license: BSD-3-Clause
+x-license: BSD-3-Clause OR Apache-2.0
+license-file: LICENSE
+author: Shayne Fletcher (shayne.fletcher@digitalasset.com)
+maintainer: Shayne Fletcher (shayne.fletcher@digitalasset.com)
+copyright: Digital Asset 2018-2024
+category: Development
+build-type: Simple
+
+common base
+  default-language: Haskell2010
+  ghc-options:
+    -Wall -Wincomplete-record-updates
+    -Wredundant-constraints -Widentities
+    -Wno-simplifiable-class-constraints
+  build-depends: base >= 4.10 && < 5
+
+common lib
+  import: base
+  build-depends:
+    extra >=1.6, optparse-applicative,
+    filepath >=1.4, containers, directory,
+    yaml, aeson, text, unordered-containers
 
 library
-  build-depends:     base >=4.10
-                     , process >=1.6
-                     , filepath >=1.4
-                     , containers
-                     , directory
-                     , optparse-applicative
-                     , bytestring
-                     , yaml
-                     , aeson
-                     , text
-                     , unordered-containers
-                     , extra >=1.6
-  hs-source-dirs:    ghc-lib-gen/src
-  exposed-modules:   Ghclibgen
-                     GhclibgenFlavor
-                     GhclibgenOpts
-  other-modules:     Paths_ghc_lib_gen
-  autogen-modules:   Paths_ghc_lib_gen
-  default-language:  Haskell2010
+  import: lib
+  hs-source-dirs: ghc-lib-gen/src
+  exposed-modules: Ghclibgen
+                   GhclibgenFlavor
+                   GhclibgenOpts
+  other-modules: Paths_ghc_lib_gen
+  autogen-modules: Paths_ghc_lib_gen
+
+common cli
+  import: base
+  build-depends: directory, optparse-applicative, ghc-lib-gen
 
 executable ghc-lib-gen
-  main-is:           ghc-lib-gen/src/Main.hs
-  build-depends:     base >=4.10
-                     , process >=1.6
-                     , filepath >=1.4
-                     , containers
-                     , directory
-                     , optparse-applicative
-                     , extra >=1.6
-                     , ghc-lib-gen
-  default-language:  Haskell2010
+  import: cli
+  main-is: ghc-lib-gen/src/Main.hs

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,5 +1,10 @@
 resolver: nightly-2023-09-21 # ghc-9.6.2
 
+extra-deps:
+  - Cabal-3.4.0.0
+allow-newer: true
+allow-newer-deps: [ghc-lib-gen]
+
 ghc-options:
   # try and speed up recompilation on the CI server
   "$everything": -O0 -j


### PR DESCRIPTION
this PR upgrades ghc-lib-gen to cabal specification 3.4 & rewrites ghc-lib-gen's cabal file using modern features. it assumes a cabal-install to be default available in the build environment to do the sdist steps involving ghc-lib-gen.

test with 
```bash
PATH="$HOME/ghc-8.8.3/bin:$PATH"; export PATH
tar xvf ghc-lib-gen-8.8.1.20240404.0.tar.gz
cd ghc-lib-gen-8.8.1.20240404.0
cabal new-build all # cabal-install version 3.10.2.1
```

the addition of `-Wall` into the build introduces some lints to go after which i plan to get to in the future