### PR TITLE
cabal for prequesites

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -51,39 +51,45 @@ strategy:
       image: "ubuntu-22.04"
       mode: "--ghc-flavor ghc-master"
       resolver: "ghc-9.6.5"
+      cabal-with-ghc: "9.6.5"
       stack-yaml: "stack-exact.yaml"
     mac-ghc-master-9.6.5:
       image: "macOS-latest"
       mode: "--ghc-flavor ghc-master"
       resolver: "ghc-9.6.5"
+      cabal-with-ghc: "9.6.5"
       stack-yaml: "stack-exact.yaml"
     windows-ghc-master-9.6.5:
       image: "windows-latest"
       mode: "--ghc-flavor ghc-master"
       resolver: "ghc-9.6.5"
+      cabal-with-ghc: "9.6.5"
       stack-yaml: "stack-exact.yaml"
 
     # +---------+-----------------+------------+
     # | OS      | ghc-lib flavor  | GHC        |
     # +=========+=================+============+
-    # | linux   | ghc-master      | ghc-9.8.1  |
-    # | macOS   | ghc-master      | ghc-9.8.1  |
-    # | windows | ghc-master      | ghc-9.8.1  |
+    # | linux   | ghc-master      | ghc-9.8.2  |
+    # | macOS   | ghc-master      | ghc-9.8.2  |
+    # | windows | ghc-master      | ghc-9.8.2  |
     # +---------+-----------------+------------+
-    linux-ghc-master-9.8.1:
+    linux-ghc-master-9.8.2:
       image: "ubuntu-22.04"
       mode: "--ghc-flavor ghc-master"
-      resolver: "ghc-9.8.1"
+      resolver: "ghc-9.8.2"
+      cabal-with-ghc: "9.8.2"
       stack-yaml: "stack-exact.yaml"
-    mac-ghc-master-9.8.1:
+    mac-ghc-master-9.8.2:
       image: "macOS-latest"
       mode: "--ghc-flavor ghc-master"
-      resolver: "ghc-9.8.1"
+      resolver: "ghc-9.8.2"
+      cabal-with-ghc: "9.8.2"
       stack-yaml: "stack-exact.yaml"
-    windows-ghc-master-9.8.1:
+    windows-ghc-master-9.8.2:
       image: "windows-latest"
       mode: "--ghc-flavor ghc-master"
-      resolver: "ghc-9.8.1"
+      resolver: "ghc-9.8.2"
+      cabal-with-ghc: "9.8.2"
       stack-yaml: "stack-exact.yaml"
 
     # +---------+-----------------+------------+
@@ -97,16 +103,19 @@ strategy:
       image: "ubuntu-22.04"
       mode: "--ghc-flavor ghc-9.10.1"
       resolver: "ghc-9.8.2"
+      cabal-with-ghc: "9.8.2"
       stack-yaml: "stack-exact.yaml"
     mac-ghc-9.10.1-9.8.2:
       image: "macOS-latest"
       mode: "--ghc-flavor ghc-9.10.1"
       resolver: "ghc-9.8.2"
+      cabal-with-ghc: "9.8.2"
       stack-yaml: "stack-exact.yaml"
     windows-ghc-9.10.1-9.8.2:
       image: "windows-latest"
       mode: "--ghc-flavor ghc-9.10.1"
       resolver: "ghc-9.8.2"
+      cabal-with-ghc: "9.8.2"
       stack-yaml: "stack-exact.yaml"
 
     # +---------+-----------------+------------+
@@ -120,16 +129,19 @@ strategy:
       image: "ubuntu-22.04"
       mode: "--da"
       resolver: "nightly-2020-01-08"
+      cabal-with-ghc: "8.8.1"
       stack-yaml: "stack.yaml"
     windows-da-ghc-8.8.1-8.8.1:
       image: "windows-latest"
       mode: "--da"
       resolver: "nightly-2020-01-08"
+      cabal-with-ghc: "8.8.1"
       stack-yaml: "stack.yaml"
     mac-da-ghc-8.8.1-8.8.1:
       image: "macOS-latest"
       mode: "--da"
       resolver: "nightly-2020-01-08"
+      cabal-with-ghc: "8.8.1"
       stack-yaml: "stack.yaml"
 
 pool: {vmImage: '$(image)'}
@@ -178,5 +190,7 @@ steps:
     condition: eq( variables['Agent.OS'], 'Linux' )
   - bash: |
       GHCLIB_AZURE=1;export GHCLIB_AZURE
+      curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | BOOTSTRAP_HASKELL_NONINTERACTIVE=1 BOOTSTRAP_HASKELL_GHC_VERSION=$(cabal-with-ghc) BOOTSTRAP_HASKELL_CABAL_VERSION=latest BOOTSTRAP_HASKELL_INSTALL_STACK=0 BOOTSTRAP_HASKELL_INSTALL_HLS=0 BOOTSTRAP_HASKELL_ADJUST_BASHRC=P sh
+      PATH="$HOME"/.ghcup/ghc/$(cabal-with-ghc)/bin:"$PATH"; export PATH
       stack runhaskell --stack-yaml $(stack-yaml) --resolver $(resolver) --package extra --package optparse-applicative -- CI.hs $(mode)  --stack-yaml $(stack-yaml) --resolver $(resolver)
     displayName: build

--- a/ghc-lib-gen/src/Main.hs
+++ b/ghc-lib-gen/src/Main.hs
@@ -23,7 +23,7 @@ main = ghclibgen =<< execParser opts
       )
 
 ghclibgen :: GhclibgenOpts -> IO ()
-ghclibgen (GhclibgenOpts root _patches target ghcFlavor skipInit cppOpts resolver) = do
+ghclibgen (GhclibgenOpts root _patches target ghcFlavor skipInit cppOpts _resolver) = do
   withCurrentDirectory root $
     case target of
       GhclibParser -> do
@@ -47,8 +47,9 @@ ghclibgen (GhclibgenOpts root _patches target ghcFlavor skipInit cppOpts resolve
 
     init :: GhcFlavor -> IO ()
     init ghcFlavor = do
+        applyPatchHadrianCabalProject ghcFlavor
         applyPatchTemplateHaskellCabal ghcFlavor
-        applyPatchHadrianStackYaml ghcFlavor resolver
+        -- applyPatchHadrianStackYaml ghcFlavor resolver
         applyPatchHeapClosures ghcFlavor
         applyPatchRtsIncludePaths ghcFlavor
         applyPatchGhcPrim ghcFlavor


### PR DESCRIPTION
i am very keen to remove stack from the build & tests processes. this step uses cabal to do the codegen steps that involve hadrian. the change means ghc-lib-gen execution doesn't call stack anymore. the result is a significant simplification.