### PR TITLE
allow happy ==2.0.2 || >=2.1.2 && <2.2

### DIFF
--- a/CI.hs
+++ b/CI.hs
@@ -98,7 +98,7 @@ data DaFlavor = DaFlavor
 
 -- Last tested gitlab.haskell.org/ghc/ghc.git at
 current :: String
-current = "c08b68bc7ab947843d20621eb483a0fc3c42703a" -- 2024-10-12
+current = "573cad4bd9e7fc146581d9711d36c4e3bacbb6e9" -- 2024-11-03
 
 ghcFlavorOpt :: GhcFlavor -> String
 ghcFlavorOpt = \case

--- a/ghc-lib-gen.cabal
+++ b/ghc-lib-gen.cabal
@@ -53,7 +53,7 @@ executable ghc-lib-gen
 executable ghc-lib-build-tool
   import: base
   if impl (ghc > 9.12.0)
-    build-tool-depends: alex:alex, happy:happy == 1.20.* || >= 2.0.2 && < 2.1
+    build-tool-depends: alex:alex, happy:happy == 1.20.* || == 2.0.2 || >= 2.1.2 && < 2.2
   else
     build-tool-depends: alex:alex, happy:happy < 2.0
   build-depends:

--- a/ghc-lib-gen/src/Ghclibgen.hs
+++ b/ghc-lib-gen/src/Ghclibgen.hs
@@ -1298,7 +1298,7 @@ libBinParserLibModules ghcFlavor = do
 happyBounds :: GhcFlavor -> String
 happyBounds ghcFlavor
   | series < GHC_9_8 = "== 1.20.*"
-  | otherwise = "== 1.20.* || >= 2.0.2 && < 2.1" -- c.f. m4/fptools_happy.m4
+  | otherwise = "== 1.20.* || == 2.0.2 || >= 2.1.2 && < 2.2" -- c.f. m4/fptools_happy.m4
   where
     series = ghcSeries ghcFlavor
 


### PR DESCRIPTION
in https://github.com/digital-asset/ghc-lib/pull/565 we allowed happy build depends < 2.1 so as to allow happy-2.0.2 (2.1 was marked deprected). since then happy 2.1.1 and 2.1.2 were released (2.1.1 is also marked deprecated). this then resulted in issue https://github.com/digital-asset/ghc-lib/issues/566 which this fixes. so, i'm changing the bounds to `happy:happy == 1.20.* || == 2.0.2 || >= 2.1.2 && < 2.2`. this change puts us out of step with GHC itself which is still < 2.1 but i guess it will catch up.