### PR TITLE
workaround ghc-9.10.1/deepseq ambiguity

### DIFF
--- a/CI.hs
+++ b/CI.hs
@@ -496,7 +496,7 @@ buildDists ghcFlavor noGhcCheckout noBuilds versionSuffix = do
     branch = \case
       Ghc9121 -> "ghc-9.12"
       Ghc9101 -> "ghc-9.10.1-release"
-      Ghc983 -> "ghc-9.8"
+      Ghc983 -> "ghc-9.8.3-release"
       Ghc982 -> "ghc-9.8.2-release"
       Ghc981 -> "ghc-9.8.1-release"
       Ghc966 -> "ghc-9.6.6-release"

--- a/ghc-lib-gen/src/Ghclibgen.hs
+++ b/ghc-lib-gen/src/Ghclibgen.hs
@@ -27,6 +27,7 @@ module Ghclibgen
     applyPatchStage,
     applyPatchNoMonoLocalBinds,
     applyPatchCmmParseNoImplicitPrelude,
+    applyPatchCompilerGHCUnitTypes,
     applyPatchHadrianCabalProject,
     applyPatchGhcInternalEventWindowsHsc,
     applyPatchTemplateHaskellLanguageHaskellTHSyntax,
@@ -1060,6 +1061,15 @@ applyPatchHadrianCabalProject _ = do
     cabalProject = "hadrian" </> "cabal.project"
     cabalProjectFreeze = cabalProject ++ ".freeze"
 
+applyPatchCompilerGHCUnitTypes :: GhcFlavor -> IO ()
+applyPatchCompilerGHCUnitTypes ghcFlavor = do
+  when (ghcFlavor == Ghc9101) $ do
+    writeFile "compiler/GHC/Unit/Types.hs"
+      . replace
+        "import Control.DeepSeq"
+        "import Control.DeepSeq (NFData(..))"
+      =<< readFile' "compiler/GHC/Unit/Types.hs"
+
 -- Data type representing an approximately parsed Cabal file.
 data Cabal = Cabal
   { cabalDir :: FilePath, -- the directory this file exists in
@@ -1175,7 +1185,8 @@ baseBounds = \case
   -- base-4.19.0.0, ghc-prim-0.11.0
   Ghc981 -> "base >= 4.17 && < 4.19.1" -- [ghc-9.4.1, ghc-9.8.2)
   -- base-4.19.1.0
-  Ghc982 -> "base >= 4.17 && < 4.20" -- [ghc-9.4.1, ghc-9.10.1)
+  Ghc982 -> "base >= 4.17 && < 4.19.2" -- [ghc-9.4.1, ghc-9.10.1)
+  -- base-4.19.2.0
   Ghc983 -> "base >= 4.17 && < 4.20" -- [ghc-9.4.1, ghc-9.10.1)
   -- base-4.20.0.0
   Ghc9101 -> "base >= 4.18 && < 4.21" -- [ghc-9.6.1, ghc-9.12.1)

--- a/ghc-lib-gen/src/Main.hs
+++ b/ghc-lib-gen/src/Main.hs
@@ -32,6 +32,7 @@ ghclibgen (GhclibgenOpts root _patches target ghcFlavor skipInit cppOpts _resolv
         applyPatchHaddockHs ghcFlavor
         applyPatchNoMonoLocalBinds ghcFlavor
         applyPatchTemplateHaskellLanguageHaskellTHSyntax ghcFlavor
+        applyPatchCompilerGHCUnitTypes ghcFlavor
         generateGhcLibParserCabal ghcFlavor cppOpts
       Ghclib -> do
         when withInit $ init ghcFlavor


### PR DESCRIPTION
(1) ghc-9.8.3 build compiler ships with deepseq 15.1.0 which breaks building ghc-9.10.1 source (showing the symptoms of https://github.com/digital-asset/ghc-lib/issues/563 see https://github.com/digital-asset/ghc-lib/issues/563#issuecomment-2453509242). the fix is already on ghc-9.12 and HEAD. the fix here is to patch ghc-lib-parser flavor ghc-9.10.1 and re-release (ghc-lib-9.10.1.20241103). i updated the happy bounds manually to `happy:happy == 1.20.* || == 2.0.2 || >= 2.1.2 && < 2.2` since there's alread a diff in flight for that in https://github.com/digital-asset/ghc-lib/pull/567.

(2) it looks like flavor ghc-9.8.3 was released from the ghc-9.8 branch, not the ghc-9.8.3 branch (my fault i guess) so that's fixed here as well. i've pushed a new release for that (ghc-lib-9.8.3.20241103) flavor and manually adjusted the happy bounds for that too `happy:happy == 1.20.* || == 2.0.2 || >= 2.1.2 && < 2.2`.
