### PR TITLE
support ghc-flavor ghc-9.8.4

### DIFF
--- a/.github/workflows/ghc-9.8.4-ghc-9.6.5.yml
+++ b/.github/workflows/ghc-9.8.4-ghc-9.6.5.yml
@@ -1,4 +1,4 @@
-name: ghc-lib-ghc-9.8.2-ghc-9.6.5
+name: ghc-lib-ghc-9.8.4-ghc-9.6.5
 on:
   push:
   pull_request:
@@ -31,9 +31,9 @@ jobs:
         shell: C:\msys64\usr\bin\bash.exe --noprofile --norc -e -o pipefail '{0}'
         run: |-
           pacman -S autoconf automake-wrapper make patch python tar mintty --noconfirm
-          cabal run exe:ghc-lib-build-tool --constraint='ghc-lib-gen +semaphore-compat' -- --ghc-flavor ghc-9.8.2
+          cabal run exe:ghc-lib-build-tool --constraint='ghc-lib-gen +semaphore-compat' -- --ghc-flavor ghc-9.8.4
         if: matrix.os == 'windows'
       - name: Run CI.hs (unix)
         shell: bash
-        run: cabal run exe:ghc-lib-build-tool --constraint='ghc-lib-gen +semaphore-compat' -- --ghc-flavor ghc-9.8.2
+        run: cabal run exe:ghc-lib-build-tool --constraint='ghc-lib-gen +semaphore-compat' -- --ghc-flavor ghc-9.8.4
         if: matrix.os == 'ubuntu' || matrix.os ==  'macos'

--- a/CI.hs
+++ b/CI.hs
@@ -47,6 +47,7 @@ data GhcFlavor
   | GhcMaster String
   | Ghc9121
   | Ghc9101
+  | Ghc984
   | Ghc983
   | Ghc982
   | Ghc981
@@ -104,6 +105,7 @@ ghcFlavorOpt :: GhcFlavor -> String
 ghcFlavorOpt = \case
   Ghc9121 -> "--ghc-flavor ghc-9.12.1"
   Ghc9101 -> "--ghc-flavor ghc-9.10.1"
+  Ghc984 -> "--ghc-flavor ghc-9.8.4"
   Ghc983 -> "--ghc-flavor ghc-9.8.3"
   Ghc982 -> "--ghc-flavor ghc-9.8.2"
   Ghc981 -> "--ghc-flavor ghc-9.8.1"
@@ -168,6 +170,7 @@ genVersionStr flavor suffix =
       GhcMaster _ -> "0"
       Ghc9121 -> "9.12.1"
       Ghc9101 -> "9.10.1"
+      Ghc984 -> "9.8.4"
       Ghc983 -> "9.8.3"
       Ghc982 -> "9.8.2"
       Ghc981 -> "9.8.1"
@@ -236,6 +239,7 @@ parseOptions =
     readFlavor = Opts.eitherReader $ \case
       "ghc-9.12.1" -> Right Ghc9121
       "ghc-9.10.1" -> Right Ghc9101
+      "ghc-9.8.4" -> Right Ghc984
       "ghc-9.8.3" -> Right Ghc983
       "ghc-9.8.2" -> Right Ghc982
       "ghc-9.8.1" -> Right Ghc981
@@ -496,6 +500,7 @@ buildDists ghcFlavor noGhcCheckout noBuilds versionSuffix = do
     branch = \case
       Ghc9121 -> "ghc-9.12"
       Ghc9101 -> "ghc-9.10.1-release"
+      Ghc984 -> "ghc-9.8.4-release"
       Ghc983 -> "ghc-9.8.3-release"
       Ghc982 -> "ghc-9.8.2-release"
       Ghc981 -> "ghc-9.8.1-release"

--- a/examples/ghc-lib-test-utils/src/TestUtils.hs
+++ b/examples/ghc-lib-test-utils/src/TestUtils.hs
@@ -58,6 +58,7 @@ data GhcVersion
   | Ghc981
   | Ghc982
   | Ghc983
+  | Ghc984
   | Ghc9101
   | Ghc9121
   | GhcMaster
@@ -70,6 +71,7 @@ showGhcVersion :: GhcVersion -> String
 showGhcVersion = \case
   Ghc9121 -> "ghc-9.12.1"
   Ghc9101 -> "ghc-9.10.1"
+  Ghc984 -> "ghc-9.8.4"
   Ghc983 -> "ghc-9.8.3"
   Ghc982 -> "ghc-9.8.2"
   Ghc981 -> "ghc-9.8.1"
@@ -114,6 +116,7 @@ readFlavor =
     -- ghc-9.10
     "ghc-9.10.1" -> Just Ghc9101
     -- ghc-9.8
+    "ghc-9.8.4" -> Just Ghc984
     "ghc-9.8.3" -> Just Ghc983
     "ghc-9.8.2" -> Just Ghc982
     "ghc-9.8.1" -> Just Ghc981

--- a/ghc-lib-gen/src/Ghclibgen.hs
+++ b/ghc-lib-gen/src/Ghclibgen.hs
@@ -937,6 +937,13 @@ mangleCSymbols ghcFlavor = do
         . prefixSymbol genSym
         . prefixSymbol initGenSym
         =<< readFile' file
+  when (ghcFlavor == Ghc984) $
+    let file = "compiler/cbits/genSym.c"
+     in writeFile file
+          . replace
+            "HsWord64 u = atomic_inc64"
+            "HsWord64 u = atomic_inc"
+          =<< readFile' file
   let files
         | ghcSeries ghcFlavor >= GHC_9_0 = map ("compiler/GHC/Types" </>) ["Unique/Supply.hs", "Unique.hs"]
         | otherwise = ["compiler/basicTypes/UniqSupply.hs"]
@@ -1188,6 +1195,7 @@ baseBounds = \case
   Ghc982 -> "base >= 4.17 && < 4.19.2" -- [ghc-9.4.1, ghc-9.10.1)
   -- base-4.19.2.0
   Ghc983 -> "base >= 4.17 && < 4.20" -- [ghc-9.4.1, ghc-9.10.1)
+  Ghc984 -> "base >= 4.17 && < 4.20" -- [ghc-9.4.1, ghc-9.10.1)
   -- base-4.20.0.0
   Ghc9101 -> "base >= 4.18 && < 4.21" -- [ghc-9.6.1, ghc-9.12.1)
   -- base-4.20.0.0 TODO bump
@@ -1218,14 +1226,14 @@ commonBuildDepends ghcFlavor =
             "containers >= 0.6.2.1 && < 0.8",
             "bytestring >= 0.11.4 && < 0.13",
             "time >= 1.4 && < 1.15",
-            "filepath >= 1 && < 1.6"
+            "filepath >= 1.5 && < 1.6"
           ]
       | ghcSeries ghcFlavor >= GHC_9_8 =
           [ "ghc-prim > 0.2 && < 0.12",
-            "containers >= 0.6.2.1 && < 0.7",
+            "containers >= 0.6.2.1 && < 0.8",
             "bytestring >= 0.11.4 && < 0.13",
-            "time >= 1.4 && < 1.13",
-            "filepath >= 1 && < 1.5"
+            "time >= 1.4 && < 1.15",
+            "filepath >= 1.5 && < 1.6"
           ]
       | ghcSeries ghcFlavor >= GHC_9_6 =
           [ "ghc-prim > 0.2 && < 0.11",

--- a/ghc-lib-gen/src/GhclibgenFlavor.hs
+++ b/ghc-lib-gen/src/GhclibgenFlavor.hs
@@ -50,6 +50,7 @@ data GhcFlavor
   | Ghc981
   | Ghc982
   | Ghc983
+  | Ghc984
   | Ghc9101
   | Ghc9121
   | GhcMaster

--- a/ghc-lib-gen/src/GhclibgenOpts.hs
+++ b/ghc-lib-gen/src/GhclibgenOpts.hs
@@ -98,6 +98,7 @@ readFlavor = eitherReader $ \case
   -- ghc-9.10
   "ghc-9.10.1" -> Right Ghc9101
   -- ghc-9.8
+  "ghc-9.8.4" -> Right Ghc984
   "ghc-9.8.3" -> Right Ghc983
   "ghc-9.8.2" -> Right Ghc982
   "ghc-9.8.1" -> Right Ghc981


### PR DESCRIPTION
- add support for ghc-9.8.4
- delete .github/workflows/ghc-9.8.2-ghc-9.6.5.yml and replace it with .github/workflows/ghc-9.8.4-ghc-9.6.5.yml.
- this likely means the branch protection rules will need updating(the list of workflows that are required to run before merging). presumably after merging this PR.