### PR TITLE
handle alex == 3.5.2.0 and ghc-9.8.4 fixes

### DIFF
--- a/.github/workflows/ghc-lib-ghc-HEAD-ghc-9.12.1.yml
+++ b/.github/workflows/ghc-lib-ghc-HEAD-ghc-9.12.1.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: haskell-actions/setup@v2
         id: setup-haskell
         with:
-          ghc-version: 9.10.1
+          ghc-version: 9.12.1
           cabal-version: 'latest'
       - name: Install build tools (macOS)
         run: brew install automake

--- a/.github/workflows/ghc-lib-ghc-master-ghc-9.12.1.yml
+++ b/.github/workflows/ghc-lib-ghc-master-ghc-9.12.1.yml
@@ -1,4 +1,4 @@
-name: ghc-lib-ghc-master-ghc-9.10.1
+name: ghc-lib-ghc-master-ghc-9.12.1
 on:
   push:
   pull_request:
@@ -15,7 +15,7 @@ jobs:
       - uses: haskell-actions/setup@v2
         id: setup-haskell
         with:
-          ghc-version: 9.10.1
+          ghc-version: 9.12.1
           cabal-version: 'latest'
       - name: Install build tools (macOS)
         run: brew install automake

--- a/CI.hs
+++ b/CI.hs
@@ -100,7 +100,7 @@ data DaFlavor = DaFlavor
 
 -- Last tested gitlab.haskell.org/ghc/ghc.git at
 current :: String
-current = "8b266671bcfe9ef5a25f0a78ea7dcca68b78dc32" -- 2024-12-19
+current = "278a53ee698d961d97afb60be9db2d8bf60b4074" -- 2024-12-30
 
 ghcFlavorOpt :: GhcFlavor -> String
 ghcFlavorOpt = \case
@@ -358,19 +358,13 @@ buildDists ghcFlavor noGhcCheckout noBuilds versionSuffix = do
       pkg_ghclib_parser = "ghc-lib-parser-" ++ version
       ghcFlavorArg = ghcFlavorOpt ghcFlavor
 
-#if __GLASGOW_HASKELL__ < 912
-  let extraCabalFlags = ""
-#else
-  let extraCabalFlags = "--allow-newer=\"hashable:base,unordered-containers:template-haskell\" "
-#endif
-
-  system_ $ "cabal build " ++ extraCabalFlags ++ "exe:ghc-lib-gen"
-  system_ $ "cabal run " ++ extraCabalFlags ++ "exe:ghc-lib-gen -- ghc ../patches --ghc-lib-parser " ++ ghcFlavorArg ++ " " ++ cppOpts ghcFlavor
+  system_ $ "cabal build " ++ "exe:ghc-lib-gen"
+  system_ $ "cabal run " ++ "exe:ghc-lib-gen -- ghc ../patches --ghc-lib-parser " ++ ghcFlavorArg ++ " " ++ cppOpts ghcFlavor
   patchVersion version "ghc/ghc-lib-parser.cabal"
   mkTarball pkg_ghclib_parser
   renameDirectory pkg_ghclib_parser "ghc-lib-parser"
   removeFile "ghc/ghc-lib-parser.cabal"
-  system_ $ "cabal run " ++ extraCabalFlags ++ "exe:ghc-lib-gen -- ghc ../patches --ghc-lib " ++ ghcFlavorArg ++ " " ++ cppOpts ghcFlavor ++ " --skip-init"
+  system_ $ "cabal run " ++ "exe:ghc-lib-gen -- ghc ../patches --ghc-lib " ++ ghcFlavorArg ++ " " ++ cppOpts ghcFlavor ++ " --skip-init"
   patchVersion version "ghc/ghc-lib.cabal"
   patchConstraints version "ghc/ghc-lib.cabal"
   mkTarball pkg_ghclib

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# ghc-lib [![Hackage version](https://img.shields.io/hackage/v/ghc-lib.svg?label=Hackage)](https://hackage.haskell.org/package/ghc-lib) [![Stackage version](https://www.stackage.org/package/ghc-lib/badge/nightly?label=Stackage)](https://www.stackage.org/package/ghc-lib) [![Build](https://github.com/digital-asset/ghc-lib/actions/workflows/ghc-lib-ghc-HEAD-ghc-9.10.1.yml/badge.svg)](https://github.com/digital-asset/ghc-lib/actions/)
+# ghc-lib [![Hackage version](https://img.shields.io/hackage/v/ghc-lib.svg?label=Hackage)](https://hackage.haskell.org/package/ghc-lib) [![Stackage version](https://www.stackage.org/package/ghc-lib/badge/nightly?label=Stackage)](https://www.stackage.org/package/ghc-lib) [![Build](https://github.com/digital-asset/ghc-lib/actions/workflows/ghc-lib-ghc-HEAD-ghc-9.12.1.yml/badge.svg)](https://github.com/digital-asset/ghc-lib/actions/)
 
-Copyright © 2019-2023, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+Copyright © 2019-2025, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 SPDX-License-Identifier: (Apache-2.0 OR BSD-3-Clause)
 
 The [GHC API](https://hackage.haskell.org/package/ghc) allows you to use the [GHC compiler](https://www.haskell.org/ghc/) as a library, so you can parse, analyze and compile Haskell code. The GHC API comes preinstalled with GHC, and is tied to that GHC version - if you are using GHC 8.6.3, you get version 8.6.3 of the API, and can't change it. The `ghc-lib` project solves that problem, letting you mix and match versions of the GHC compiler and GHC API. Why might you want that?

--- a/ghc-lib-gen.cabal
+++ b/ghc-lib-gen.cabal
@@ -53,9 +53,9 @@ executable ghc-lib-gen
 executable ghc-lib-build-tool
   import: base
   if impl (ghc > 9.12.0)
-    build-tool-depends: alex:alex, happy:happy == 1.20.* || == 2.0.2 || >= 2.1.2 && < 2.2
+    build-tool-depends: alex:alex < 3.5.2.0, happy:happy == 1.20.* || == 2.0.2 || >= 2.1.2 && < 2.2
   else
-    build-tool-depends: alex:alex, happy:happy < 2.0
+    build-tool-depends: alex:alex < 3.5.2.0, happy:happy < 2.0
   build-depends:
     directory, filepath, time, extra, optparse-applicative
   if flag(semaphore-compat)

--- a/ghc-lib-gen.cabal
+++ b/ghc-lib-gen.cabal
@@ -53,9 +53,9 @@ executable ghc-lib-gen
 executable ghc-lib-build-tool
   import: base
   if impl (ghc > 9.12.0)
-    build-tool-depends: alex:alex < 3.5.2.0, happy:happy == 1.20.* || == 2.0.2 || >= 2.1.2 && < 2.2
+    build-tool-depends: alex:alex, happy:happy == 1.20.* || == 2.0.2 || >= 2.1.2 && < 2.2
   else
-    build-tool-depends: alex:alex < 3.5.2.0, happy:happy < 2.0
+    build-tool-depends: alex:alex, happy:happy < 2.0
   build-depends:
     directory, filepath, time, extra, optparse-applicative
   if flag(semaphore-compat)

--- a/ghc-lib-gen/src/Ghclibgen.hs
+++ b/ghc-lib-gen/src/Ghclibgen.hs
@@ -320,6 +320,9 @@ calcModuleDeps includeDirs _hsSrcDirs hsSrcIncludes ghcFlavor cabalPackageDb ghc
     [ ["ghc -M -dep-suffix '' -dep-makefile " ++ ghcMakeModeOutputFile],
       ["-clear-package-db -global-package-db -user-package-db -package-db " ++ cabalPackageDb],
       ["-package semaphore-compat" | series >= GHC_9_8],
+#if __GLASGOW_HASKELL__ == 908 && __GLASGOW_HASKELL_PATCHLEVEL1__ == 4
+      ["-hide-package os-string"], -- avoid System.OsString ambiguity with filepath-1.4.301.0
+#endif
       ["-fno-safe-haskell" | series >= GHC_9_0], -- avoid warning: [GHC-98887] -XGeneralizedNewtypeDeriving is not allowed in Safe Haskell; ignoring -XGeneralizedNewtypeDeriving
       ["-DBIGNUM_NATIVE" | series > GHC_9_12],
       includeDirs,
@@ -938,6 +941,7 @@ mangleCSymbols ghcFlavor = do
    in writeFile file
         . prefixSymbol genSym
         . prefixSymbol initGenSym
+        . replace "#if !MIN_VERSION_GLASGOW_HASKELL(9,9,0,0)" "#if !MIN_VERSION_GLASGOW_HASKELL(9,8,4,0)"
         =<< readFile' file
   when (ghcFlavor == Ghc984) $
     let file = "compiler/cbits/genSym.c"

--- a/ghc-lib-gen/src/Ghclibgen.hs
+++ b/ghc-lib-gen/src/Ghclibgen.hs
@@ -1314,7 +1314,7 @@ libBinParserLibModules ghcFlavor = do
 
 happyBounds :: GhcFlavor -> String
 happyBounds ghcFlavor
-  | series < GHC_9_8 = "== 1.20.*"
+  | series < GHC_9_8 = "< 1.21"
   | otherwise = "== 1.20.* || == 2.0.2 || >= 2.1.2 && < 2.2" -- c.f. m4/fptools_happy.m4
   where
     series = ghcSeries ghcFlavor
@@ -1393,7 +1393,7 @@ generateGhcLibCabal ghcFlavor customCppOpts = do
         "    build-depends:"
       ],
       indent2 (Data.List.NonEmpty.toList (withCommas (ghcLibBuildDepends ghcFlavor))),
-      ["    build-tool-depends: alex:alex >= 3.1, " ++ "happy:happy " ++ happyBounds ghcFlavor],
+      ["    build-tool-depends: alex:alex >= 3.1 && < 3.5.2.0, " ++ "happy:happy " ++ happyBounds ghcFlavor],
       ["    other-extensions:"],
       indent2 (askField lib "other-extensions:"),
       ["    default-extensions:"],
@@ -1513,7 +1513,7 @@ generateGhcLibParserCabal ghcFlavor customCppOpts = do
       [ "    if impl(ghc >= 9.10)",
         "      build-depends: ghc-internal"
       ],
-      ["    build-tool-depends: alex:alex >= 3.1, " ++ "happy:happy " ++ happyBounds ghcFlavor],
+      ["    build-tool-depends: alex:alex >= 3.1 && < 3.5.2.0, " ++ "happy:happy " ++ happyBounds ghcFlavor],
       ["    other-extensions:"],
       indent2 (askField lib "other-extensions:"),
       ["    default-extensions:"],

--- a/ghc-lib-gen/src/Ghclibgen.hs
+++ b/ghc-lib-gen/src/Ghclibgen.hs
@@ -141,7 +141,7 @@ ghcLibHsSrcDirs forDepends ghcFlavor lib =
           GHC_9_4 -> ["ghc-lib/stage0/libraries/ghc-boot/build", "libraries/template-haskell", "libraries/ghc-boot-th", "libraries/ghc-heap", "libraries/ghci"]
           GHC_9_6 -> ["libraries/template-haskell", "libraries/ghc-boot-th", "libraries/ghc-boot", "libraries/ghc-heap", "libraries/ghci"]
           GHC_9_8 -> ["libraries/template-haskell", "libraries/ghc-boot-th", "libraries/ghc-boot", "libraries/ghc-heap", "libraries/ghc-platform/src", "libraries/ghc-platform"]
-          GHC_9_10 -> ["libraries/template-haskell", "libraries/ghc-boot-th", "libraries/ghc-boot", "libraries/ghc-heap", "libraries/ghc-platform/src", "libraries/ghc-platform", "libraries/ghci"]
+          GHC_9_10 -> ["libraries/template-haskell", "libraries/ghc-boot-th", "libraries/ghc-boot-th-internal", "libraries/ghc-boot", "libraries/ghc-heap", "libraries/ghc-platform/src", "libraries/ghc-platform", "libraries/ghci"]
           GHC_9_12 -> ["libraries/template-haskell", "libraries/ghc-boot-th", "libraries/ghc-boot-th-internal", "libraries/ghc-boot", "libraries/ghc-heap", "libraries/ghc-platform/src", "libraries/ghc-platform", "libraries/ghci", "libraries/ghc-internal/src"]
           GHC_9_14 -> ["libraries/template-haskell", "libraries/ghc-boot-th", "libraries/ghc-boot-th-internal", "libraries/ghc-boot", "", "libraries/ghc-heap", "libraries/ghc-platform/src", "libraries/ghc-platform", "libraries/ghci", "libraries/ghc-internal/src"]
    in sortDiffListByLength all $ Set.fromList [dir | not forDepends, dir <- exclusions]

--- a/ghc-lib-gen/src/Ghclibgen.hs
+++ b/ghc-lib-gen/src/Ghclibgen.hs
@@ -1578,7 +1578,7 @@ generatePrerequisites ghcFlavor = do
   system_ "bash -c ./boot"
   system_ "bash -c \"./configure --enable-tarballs-autodownload\""
   withCurrentDirectory "hadrian" $ do
-    system_ $ "cabal build exe:hadrian --ghc-options=-j"
+    system_ "cabal build exe:hadrian --ghc-options=-j"
     system_ . unwords . join $
       [ [ "cabal run exe:hadrian --",
           "--directory=..",

--- a/ghc-lib-gen/src/Main.hs
+++ b/ghc-lib-gen/src/Main.hs
@@ -53,6 +53,7 @@ ghclibgen (GhclibgenOpts root _patches target ghcFlavor skipInit cppOpts _resolv
       applyPatchGhcPrim ghcFlavor
       applyPatchDisableCompileTimeOptimizations ghcFlavor
       -- These lines must come before 'generatePrerequisites':
+      applyPatchCompilerGHCParserLexer ghcFlavor
       applyPatchAclocal ghcFlavor -- Do before ./boot && ./configure
       applyPatchFptoolsAlex ghcFlavor
       applyPatchFpFindCxxStdLib ghcFlavor


### PR DESCRIPTION
(commit 245912d61e7e08b14b7cb7d735411968a46fd481): alex-3.5.2.0 was released to hackage on 2024-12-30. it produces errors like this
```
compiler/GHC/Parser/Lexer.x:3471:12: error: [GHC-31744]
    Duplicate INLINE pragmas for ‘alexScanUser’
    at /home/runner/work/ghc-lib/ghc-lib/dist-newstyle/build/x86_64-linux/ghc-9.10.1/ghc-lib-parser-0.20241231/build/GHC/Parser/Lexer.hs:1383:12-23
       compiler/GHC/Parser/Lexer.x:3471:12-23
     |
3471 | -- in this file, alexScanUser gets broken out into a separate function and
     |            ^^^^^^^^^^^^
```
on flavors >= ghc-9.12.1 e.g. https://github.com/digital-asset/ghc-lib/actions/runs/12553438884. verified that this is a problem for GHC too. see https://github.com/haskell/alex/issues/266

(commit 81196e9575855cb935d1c4fc00b1032ac4bc80d2): two more fixes relating to 9.8.4 as a build compiler
  - hide os-string during calculating parser module deps in ghc-lib-gen to avoid ambiguity with filepath
  - avoid link errors resulting from duplicate symbol definitions from 'genSym.c'

(commit 27e242140152f81f4d232c368f89d6ebd88721a1): add an exclusion to ghc-lib's hs-src dirs

(commit 29ca22c1c3e8fb4b45b7d426d656d1027f8397af): https://github.com/haskell-hvr/cryptohash-sha256/issues/25 got closed enabling us to remove the extra hadrian cabal flags from 'Ghclibgen.hs' and ghcup now serves ghc-9.12.1 so, move ghc-lib-ghc-HEAD-ghc-9.10.1.yml to ghc-lib-ghc-HEAD-ghc-9.12.1.yml, ghc-lib-ghc-master-ghc-9.10.1.yml to ghc-lib-ghc-master-ghc-9.12.1.yml (updating the build compiler to ghc-9.12.1 accordingly) and update the README build badge (after landing this it's probably necessary to modify the repository "required test" settings).

(commit 5ea361cf417d5dc2fda5a6b8d8f4b67de5e62cb5): remove `{-# INLINE alexScanUser #-}` from `Lexer.x` to enable alex-3.5.2.0 and unblock stackage (see https://gitlab.haskell.org/ghc/ghc/-/merge_requests/13782#note_602621 for details)