### PR TITLE
ghc-prim is merged with ghc-internal

### DIFF
--- a/.github/workflows/hlint-check.yml
+++ b/.github/workflows/hlint-check.yml
@@ -13,7 +13,7 @@ jobs:
     - name: 'ghc-lib'
       uses: haskell-actions/hlint-run@v2
       with:
-        path: '["CI.hs", "ghc-lib-gen/src", "examples/ghc-lib-test-utils/src"]'
+        path: '["CI.hs", "examples/ghc-lib-test-utils/src"]'
         fail-on: warning
   hlint-examples:
     runs-on: ubuntu-latest

--- a/CI.hs
+++ b/CI.hs
@@ -100,7 +100,7 @@ data DaFlavor = DaFlavor
 
 -- Last tested gitlab.haskell.org/ghc/ghc.git at
 current :: String
-current = "595013d41464c1e328369bb81ce0ea2814e91b68" -- 2025-01-24
+current = "70f7741acd9d50a6cc07553aeaae600afe4a72b8" -- 2025-01-26
 
 ghcFlavorOpt :: GhcFlavor -> String
 ghcFlavorOpt = \case
@@ -421,7 +421,14 @@ buildDists ghcFlavor noGhcCheckout noBuilds versionSuffix = do
   cmd "cabal build --ghc-options=-j all"
 
   system_ $ "cd examples/ghc-lib-test-mini-hlint && cabal test --project-dir ../.. --test-show-details direct --test-options \"--color always --test-command ../../ghc-lib-test-mini-hlint " ++ ghcFlavorArg ++ "\""
-  system_ $ "cd examples/ghc-lib-test-mini-compile && cabal test --project-dir ../.. --test-show-details direct --test-options \"--color always --test-command ../../ghc-lib-test-mini-compile " ++ ghcFlavorArg ++ "\""
+
+  -- TODO: Fix me. This test is failing since ghc-prim merged with
+  -- ghc-internal
+  -- https://gitlab.haskell.org/ghc/ghc/-/merge_requests/13752
+  case ghcFlavor of
+    GhcMaster _ -> pure ()
+    _ -> system_ $ "cd examples/ghc-lib-test-mini-compile && cabal test --project-dir ../.. --test-show-details direct --test-options \"--color always --test-command ../../ghc-lib-test-mini-compile " ++ ghcFlavorArg ++ "\""
+
   system_ "cabal -v0 exec -- ghc -ignore-dot-ghci -package=ghc-lib-parser -e \"print 1\""
   system_ "cabal -v0 exec -- ghc -ignore-dot-ghci -package=ghc-lib -e \"print 1\""
 

--- a/CI.hs
+++ b/CI.hs
@@ -100,7 +100,7 @@ data DaFlavor = DaFlavor
 
 -- Last tested gitlab.haskell.org/ghc/ghc.git at
 current :: String
-current = "278a53ee698d961d97afb60be9db2d8bf60b4074" -- 2024-12-30
+current = "595013d41464c1e328369bb81ce0ea2814e91b68" -- 2025-01-24
 
 ghcFlavorOpt :: GhcFlavor -> String
 ghcFlavorOpt = \case

--- a/CI.hs
+++ b/CI.hs
@@ -100,7 +100,7 @@ data DaFlavor = DaFlavor
 
 -- Last tested gitlab.haskell.org/ghc/ghc.git at
 current :: String
-current = "70f7741acd9d50a6cc07553aeaae600afe4a72b8" -- 2025-01-26
+current = "70f7741acd9d50a6cc07553aeaae600afe4a72b8" -- 2025-01-27
 
 ghcFlavorOpt :: GhcFlavor -> String
 ghcFlavorOpt = \case
@@ -421,13 +421,7 @@ buildDists ghcFlavor noGhcCheckout noBuilds versionSuffix = do
   cmd "cabal build --ghc-options=-j all"
 
   system_ $ "cd examples/ghc-lib-test-mini-hlint && cabal test --project-dir ../.. --test-show-details direct --test-options \"--color always --test-command ../../ghc-lib-test-mini-hlint " ++ ghcFlavorArg ++ "\""
-
-  -- TODO: Fix me. This test is failing since ghc-prim merged with
-  -- ghc-internal
-  -- https://gitlab.haskell.org/ghc/ghc/-/merge_requests/13752
-  case ghcFlavor of
-    GhcMaster _ -> pure ()
-    _ -> system_ $ "cd examples/ghc-lib-test-mini-compile && cabal test --project-dir ../.. --test-show-details direct --test-options \"--color always --test-command ../../ghc-lib-test-mini-compile " ++ ghcFlavorArg ++ "\""
+  system_ $ "cd examples/ghc-lib-test-mini-compile && cabal test --project-dir ../.. --test-show-details direct --test-options \"--color always --test-command ../../ghc-lib-test-mini-compile " ++ ghcFlavorArg ++ "\""
 
   system_ "cabal -v0 exec -- ghc -ignore-dot-ghci -package=ghc-lib-parser -e \"print 1\""
   system_ "cabal -v0 exec -- ghc -ignore-dot-ghci -package=ghc-lib -e \"print 1\""

--- a/examples/ghc-lib-test-mini-compile/ghc-lib-test-mini-compile.cabal
+++ b/examples/ghc-lib-test-mini-compile/ghc-lib-test-mini-compile.cabal
@@ -22,6 +22,7 @@ executable ghc-lib-test-mini-compile
                      , containers
                      , directory
                      , extra
+                     , filepath
                      , ghc-lib-parser
                      , ghc-lib
   hs-source-dirs:      src

--- a/examples/ghc-lib-test-mini-compile/test/GHC/Internal/Prim.hs
+++ b/examples/ghc-lib-test-mini-compile/test/GHC/Internal/Prim.hs
@@ -1,0 +1,1 @@
+module GHC.Internal.Prim where

--- a/examples/ghc-lib-test-mini-compile/test/MiniCompileTestGhcInternalPrim.hs
+++ b/examples/ghc-lib-test-mini-compile/test/MiniCompileTestGhcInternalPrim.hs
@@ -1,0 +1,92 @@
+-- Copyright (c) 2019-2025, Digital Asset (Switzerland) GmbH and/or
+-- its affiliates. All rights reserved. SPDX-License-Identifier:
+-- (Apache-2.0 OR BSD-3-Clause)
+-- Based on
+-- https://github.com/ghc/ghc/blob/23f6f31dd66d7c370cb8beec3f1d96a0cb577393/libraries/ghc-prim/GHC/Types.hs
+
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE MagicHash #-}
+
+module GHC.Internal.Types (
+        -- Data types that are built-in syntax
+        -- They are defined here, but not explicitly exported
+        --
+        --    Lists:          []( [], (::) )
+
+        Bool(..), Int (..), Word, TextLit,
+        Ordering(..),
+        Symbol,
+        ifThenElse,
+        Multiplicity(..)
+    ) where
+
+import GHC.Internal.Prim
+
+infixr 5 :
+
+-- | The kind of constraints, like `Show a`
+data Constraint
+
+data Multiplicity = Many | One
+
+-- | (Kind) This is the kind of type-level symbols.
+-- Declared here because class IP needs it
+data Symbol
+
+-- | Documentation for lists
+data [] a = [] | a : [a]
+
+
+-- | Information about ordering
+data Ordering = LT | EQ | GT
+
+-- | A 64-bit integer.
+data Int =
+  I# Int#
+
+-- This is a dummy type we need for string literals.
+data Char
+
+type TextLit = [Char]
+
+-- A dummy type for Word.
+data Word
+
+data Bool = False | True
+
+isTrue# :: Int# -> Bool
+{-# INLINE isTrue# #-}
+isTrue# x = tagToEnum# x
+
+ifThenElse :: Bool -> a -> a -> a
+ifThenElse c t f = case c of True -> t; False -> f
+
+data Module = Module
+                TrName   -- Package name
+                TrName   -- Module name
+
+data TrName
+  = TrNameS Addr#  -- Static
+  | TrNameD [Char] -- Dynamic
+
+type KindBndr = Int
+
+data RuntimeRep
+
+data KindRep = KindRepTyConApp TyCon [KindRep]
+             | KindRepVar !KindBndr
+             | KindRepApp KindRep KindRep
+             | KindRepFun KindRep KindRep
+             | KindRepTYPE !RuntimeRep
+             | KindRepTypeLitS TypeLitSort Addr#
+             | KindRepTypeLitD TypeLitSort [Char]
+
+data TypeLitSort = TypeLitSymbol
+                 | TypeLitNat
+                 | TypeLitChar
+
+data TyCon = TyCon Word# Word#           -- Fingerprint
+                   Module                -- Module in which this is defined
+                   TrName                -- Type constructor name
+                   Int#                  -- How many kind variables do we accept?
+                   KindRep               -- A representation of the type's kind

--- a/examples/ghc-lib-test-utils/src/TestUtils.hs
+++ b/examples/ghc-lib-test-utils/src/TestUtils.hs
@@ -64,6 +64,9 @@ data GhcVersion
   | GhcMaster
   deriving (Eq, Ord, Typeable)
 
+data GhcSeries = GHC_8_8 | GHC_8_10 | GHC_9_0 | GHC_9_2 | GHC_9_4 | GHC_9_6 | GHC_9_8 | GHC_9_10 | GHC_9_12 | GHC_9_14
+  deriving (Eq, Ord)
+
 instance Show GhcVersion where
   show = showGhcVersion
 
@@ -105,6 +108,19 @@ showGhcVersion = \case
 
 newtype GhcFlavor = GhcFlavor GhcVersion
   deriving (Eq, Ord, Typeable)
+
+ghcSeries :: GhcFlavor -> GhcSeries
+ghcSeries (GhcFlavor f)
+  | DaGhc881 <= f && f < Ghc8101 = GHC_8_8
+  | Ghc8101 <= f && f < Ghc901 = GHC_8_10
+  | Ghc901 <= f && f < Ghc921 = GHC_9_0
+  | Ghc921 <= f && f < Ghc941 = GHC_9_2
+  | Ghc941 <= f && f < Ghc961 = GHC_9_4
+  | Ghc961 <= f && f < Ghc981 = GHC_9_6
+  | Ghc981 <= f && f < Ghc9101 = GHC_9_8
+  | Ghc9101 <= f && f < Ghc9121 = GHC_9_10
+  | Ghc9121 <= f && f < GhcMaster = GHC_9_12
+  | otherwise = GHC_9_14
 
 readFlavor :: String -> Maybe GhcFlavor
 readFlavor =

--- a/ghc-lib-gen/src/Ghclibgen.hs
+++ b/ghc-lib-gen/src/Ghclibgen.hs
@@ -942,8 +942,12 @@ mangleCSymbols ghcFlavor = do
    in writeFile file
         . prefixSymbol genSym
         . prefixSymbol initGenSym
-        . replace "#if !MIN_VERSION_GLASGOW_HASKELL(9,9,0,0)" "#if !MIN_VERSION_GLASGOW_HASKELL(9,8,4,0)"
-        =<< readFile' file
+          =<< readFile' file
+  when (ghcFlavor <= Ghc9121) $
+    let file = "compiler/cbits/genSym.c"
+    in writeFile file
+       . replace "#if !MIN_VERSION_GLASGOW_HASKELL(9,9,0,0)" "#if !MIN_VERSION_GLASGOW_HASKELL(9,8,4,0)"
+       =<< readFile' file
   when (ghcFlavor == Ghc984) $
     let file = "compiler/cbits/genSym.c"
      in writeFile file


### PR DESCRIPTION
[this MR](https://gitlab.haskell.org/ghc/ghc/-/merge_requests/13752) merges ghc-prim into ghc-internal.

in this PR i manage to get ghc-lib-parser working again. the main ideas are: for ghc-9.12.1 ghc -M does not need any source paths to ghc-internal modules and neither do any need mentioning in either of the generated cabal files. that's not true for ghc-9.10.1 unfortunately so put some cpp around that.

the build of ghc-lib/ghc-lib-test-mini-compile succeeds but i've disabled testing of ghc-lib-test-mini-compile. this is a failing testg since this merge and i don't know how to fix it. i tested an equivalent program with a build of ghc after the MR and it fails in the same way (can't resolve `GHC.Internal.Prim`). i raised an issue upstream https://gitlab.haskell.org/ghc/ghc/-/issues/25686

ghc-lib-test-mini-compile tests:

- manual
```
(cd examples/ghc-lib-test-mini-compile && cabal run exe:ghc-lib-test-mini-compile --project-dir ../.. -- test/MiniCompileTestGhcInternalPrim.hs)
```

- what CI.hs does
```
(cd examples/ghc-lib-test-mini-compile && cabal test --project-dir ../.. --test-show-details direct --test-options "--color always --test-command ../../ghc-lib-test-mini-compile --ghc-flavor ghc-master")
```
where '../../ghc-lib-test-mini-compile' it generates with contents like `cabal -v0 run exe:ghc-lib-test-mini-compile --project-dir ../.. -- `.


