### PR TITLE
ghc 9.12.2

### DIFF
--- a/.github/workflows/ghc-9.12.2-ghc-9.10.1.yml
+++ b/.github/workflows/ghc-9.12.2-ghc-9.10.1.yml
@@ -1,4 +1,4 @@
-name: ghc-lib-ghc-9.12.1-ghc-9.10.1
+name: ghc-lib-ghc-9.12.2-ghc-9.10.1
 on:
   push:
   pull_request:
@@ -31,9 +31,9 @@ jobs:
         shell: C:\msys64\usr\bin\bash.exe --noprofile --norc -e -o pipefail '{0}'
         run: |-
           pacman -S autoconf automake-wrapper make patch python tar mintty --noconfirm
-          cabal run exe:ghc-lib-build-tool -- --ghc-flavor ghc-9.12.1
+          cabal run exe:ghc-lib-build-tool -- --ghc-flavor ghc-9.12.2
         if: matrix.os == 'windows'
       - name: Run CI.hs (unix)
         shell: bash
-        run: cabal run exe:ghc-lib-build-tool -- --ghc-flavor ghc-9.12.1
+        run: cabal run exe:ghc-lib-build-tool -- --ghc-flavor ghc-9.12.2
         if: matrix.os == 'ubuntu' || matrix.os ==  'macos'

--- a/CI.hs
+++ b/CI.hs
@@ -46,6 +46,7 @@ data Options = Options
 data GhcFlavor
   = Da DaFlavor
   | GhcMaster String
+  | Ghc9122
   | Ghc9121
   | Ghc9101
   | Ghc985
@@ -101,10 +102,11 @@ data DaFlavor = DaFlavor
 
 -- Last tested gitlab.haskell.org/ghc/ghc.git at
 current :: String
-current = "e576468c0ff302ea00f8b4c130587db29ac344ea" -- 2025-03-19
+current = "25d46547f8767475d8ab98cac07c78571848ef18" -- 2025-03-19
 
 ghcFlavorOpt :: GhcFlavor -> String
 ghcFlavorOpt = \case
+  Ghc9122 -> "--ghc-flavor ghc-9.12.2"
   Ghc9121 -> "--ghc-flavor ghc-9.12.1"
   Ghc9101 -> "--ghc-flavor ghc-9.10.1"
   Ghc985 -> "--ghc-flavor ghc-9.8.5"
@@ -171,6 +173,7 @@ genVersionStr flavor suffix =
     base = case flavor of
       Da {} -> "8.8.1"
       GhcMaster _ -> "0"
+      Ghc9122 -> "9.12.2"
       Ghc9121 -> "9.12.1"
       Ghc9101 -> "9.10.1"
       Ghc985 -> "9.8.5"
@@ -241,6 +244,7 @@ parseOptions =
   where
     readFlavor :: Opts.ReadM GhcFlavor
     readFlavor = Opts.eitherReader $ \case
+      "ghc-9.12.2" -> Right Ghc9122
       "ghc-9.12.1" -> Right Ghc9121
       "ghc-9.10.1" -> Right Ghc9101
       "ghc-9.8.5" -> Right Ghc985
@@ -512,6 +516,7 @@ buildDists ghcFlavor noGhcCheckout noBuilds versionSuffix = do
 
     branch :: GhcFlavor -> String
     branch = \case
+      Ghc9122 -> "ghc-9.12.2-release"
       Ghc9121 -> "ghc-9.12.1-release"
       Ghc9101 -> "ghc-9.10.1-release"
       Ghc985 -> "ghc-9.8"

--- a/examples/ghc-lib-test-utils/src/TestUtils.hs
+++ b/examples/ghc-lib-test-utils/src/TestUtils.hs
@@ -62,6 +62,7 @@ data GhcVersion
   | Ghc985
   | Ghc9101
   | Ghc9121
+  | Ghc9122
   | GhcMaster
   deriving (Eq, Ord, Typeable)
 
@@ -73,6 +74,7 @@ instance Show GhcVersion where
 
 showGhcVersion :: GhcVersion -> String
 showGhcVersion = \case
+  Ghc9122 -> "ghc-9.12.2"
   Ghc9121 -> "ghc-9.12.1"
   Ghc9101 -> "ghc-9.10.1"
   Ghc985 -> "ghc-9.8.5"
@@ -130,6 +132,7 @@ readFlavor =
     -- HEAD
     "ghc-master" -> Just GhcMaster
     -- ghc-9.12
+    "ghc-9.12.2" -> Just Ghc9122
     "ghc-9.12.1" -> Just Ghc9121
     -- ghc-9.10
     "ghc-9.10.1" -> Just Ghc9101

--- a/ghc-lib-gen/src/Ghclibgen.hs
+++ b/ghc-lib-gen/src/Ghclibgen.hs
@@ -1239,6 +1239,7 @@ baseBounds = \case
   Ghc9101 -> "base >= 4.18 && < 4.21" -- [ghc-9.6.1, ghc-9.12.1)
   -- base-4.21.0.0
   Ghc9121 -> "base >= 4.19 && < 4.22" -- [ghc-9.8.1, ghc-9.14.1)
+  Ghc9122 -> "base >= 4.19 && < 4.22" -- [ghc-9.8.1, ghc-9.14.1)
   GhcMaster ->
     -- e.g. "9.11.20230119"
     -- (c.f. 'rts/include/ghcversion.h')

--- a/ghc-lib-gen/src/GhclibgenFlavor.hs
+++ b/ghc-lib-gen/src/GhclibgenFlavor.hs
@@ -54,6 +54,7 @@ data GhcFlavor
   | Ghc985
   | Ghc9101
   | Ghc9121
+  | Ghc9122
   | GhcMaster
   deriving (Show, Eq, Ord)
 

--- a/ghc-lib-gen/src/GhclibgenOpts.hs
+++ b/ghc-lib-gen/src/GhclibgenOpts.hs
@@ -94,6 +94,7 @@ readFlavor = eitherReader $ \case
   -- HEAD
   "ghc-master" -> Right GhcMaster
   -- ghc-9.12
+  "ghc-9.12.2" -> Right Ghc9122
   "ghc-9.12.1" -> Right Ghc9121
   -- ghc-9.10
   "ghc-9.10.1" -> Right Ghc9101


### PR DESCRIPTION
ghc-9.12.2 was released 2025-03-19.

needs rebasing on master after https://github.com/digital-asset/ghc-lib/pull/589 https://github.com/digital-asset/ghc-lib/pull/590 have landed