### PR TITLE
recover from th internal changes

### DIFF
--- a/CI.hs
+++ b/CI.hs
@@ -104,7 +104,7 @@ data DaFlavor = DaFlavor
 
 -- Last tested gitlab.haskell.org/ghc/ghc.git at
 current :: String
-current = "2da84b7a83f723dc6531cdad5ef3c7e624fda2fe" -- 2025-09-02
+current = "9d626be140de24004414188aa5fee74187d255e5" -- 2025-09-05
 
 ghcFlavorOpt :: GhcFlavor -> String
 ghcFlavorOpt = \case
@@ -373,11 +373,6 @@ buildDists ghcFlavor noGhcCheckout noBuilds versionSuffix = do
   when ghcBootThGHCInternalDirExists $ do
     system_ "bash -c \"mkdir -p ghc/libraries/ghc-boot-th-internal/GHC\""
     system_ "bash -c \"mv ghc/libraries/ghc-boot-th/GHC/Internal ghc/libraries/ghc-boot-th-internal/GHC\""
-
-  ghcInternalHeapDirExists <- doesDirectoryExist "ghc/libraries/ghc-internal/src/GHC/Internal/Heap"
-  when ghcInternalHeapDirExists $ do
-    system_ "bash -c \"mkdir -p ghc/libraries/ghc-internal-heap/src/GHC/Internal\""
-    system_ "bash -c \"mv ghc/libraries/ghc-internal/src/GHC/Internal/Heap ghc/libraries/ghc-internal-heap/src/GHC/Internal\""
 
   version <- tag
   let pkg_ghclib = "ghc-lib-" ++ version

--- a/examples/ghc-lib-test-mini-compile/src/Main.hs
+++ b/examples/ghc-lib-test-mini-compile/src/Main.hs
@@ -476,6 +476,8 @@ fakeSettings = Settings {
 
     toolSettings = ToolSettings {
          toolSettings_opt_P_fingerprint=fingerprint0
+       , toolSettings_opt_JSP_fingerprint=fingerprint0
+       , toolSettings_opt_CmmP_fingerprint=fingerprint0
        }
 
     platformMisc = PlatformMisc {


### PR DESCRIPTION
recover from https://gitlab.haskell.org/ghc/ghc/-/commit/39e1b7cb8cdf09d7782e0d8f1cb7779374349994

```
x ghc-lib-parser-0.20250905/libraries/ghc-internal/src/GHC/Internal/ForeignSrcLang.hs
x ghc-lib-parser-0.20250905/libraries/ghc-internal/src/GHC/Internal/Heap/
x ghc-lib-parser-0.20250905/libraries/ghc-internal/src/GHC/Internal/Heap/Closures.hs
x ghc-lib-parser-0.20250905/libraries/ghc-internal/src/GHC/Internal/Heap/Constants.hsc
x ghc-lib-parser-0.20250905/libraries/ghc-internal/src/GHC/Internal/Heap/InfoTable.hsc
x ghc-lib-parser-0.20250905/libraries/ghc-internal/src/GHC/Internal/Heap/InfoTable/
x ghc-lib-parser-0.20250905/libraries/ghc-internal/src/GHC/Internal/Heap/InfoTable/Types.hsc
x ghc-lib-parser-0.20250905/libraries/ghc-internal/src/GHC/Internal/Heap/InfoTableProf.hsc
x ghc-lib-parser-0.20250905/libraries/ghc-internal/src/GHC/Internal/Heap/ProfInfo/
x ghc-lib-parser-0.20250905/libraries/ghc-internal/src/GHC/Internal/Heap/ProfInfo/Types.hs
x ghc-lib-parser-0.20250905/libraries/ghc-internal/src/GHC/Internal/LanguageExtensions.hs
x ghc-lib-parser-0.20250905/libraries/ghc-internal/src/GHC/Internal/Lexeme.hs
x ghc-lib-parser-0.20250905/libraries/ghc-internal/src/GHC/Internal/TH/
x ghc-lib-parser-0.20250905/libraries/ghc-internal/src/GHC/Internal/TH/Monad.hs
x ghc-lib-parser-0.20250905/libraries/ghc-internal/src/GHC/Internal/TH/Syntax.hs
```